### PR TITLE
Possible problem with channel-seq

### DIFF
--- a/aleph-core/test/aleph/test/channel.clj
+++ b/aleph-core/test/aleph/test/channel.clj
@@ -135,3 +135,18 @@
 	  (Thread/sleep 0 1)))
       (dotimes [i num]
 	(is (= i (wait-for-message ch)))))))
+
+(deftest test-channel-seq
+  (let [ch (channel)
+        in (take 100 (iterate inc 0))
+        out (do (future
+                 (doseq [i in]
+                   (enqueue ch i)
+                   (Thread/sleep 1)))
+                (loop [out []]
+                  (Thread/sleep 3)
+                  (let [n (channel-seq ch)]
+                    (if (seq n)
+                      (recur (concat out n))
+                      out))))]
+    (is (= in out))))


### PR DESCRIPTION
Hi Zach,

This pull request contains a failing test for channel-seq. When items are being added in one thread with enqueue and then removed in another thread with channel-seq, some items are missed. It it always the first item in the list that returns from channel-seq that is missing.

The weird thing is that when I create a channel and then enqueue 1, 2 and 3, I can call (channel-seq ch) and will get [1 2 3]. But if I then run this code:

```
(future
  (dotimes [i 100]
    (enqueue ch i)
    (Thread/sleep 100)))
```

and then empty the channel with multiple calls to channel-seq, and then do the same thing (add 1, 2 and 3), (channel-seq ch) will return only [2 3].

I may be wrong, but I don't think this is the correct behavior. Sorry I didn't even try to fix it in this patch. It's getting late and I am just getting started with aleph so maybe I'm missing something.

Thanks for your work on aleph. I hope I will be able to make it over to the BACUG to catch your presentation on the 7th.

Cheers,
Brenton
