### PR TITLE
POST request handling

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -79,7 +79,9 @@
     (when-not (zero? (.readableBytes body))
       (cond
 
-	(and auto-transform? (.startsWith ^String content-type "text"))
+       (and auto-transform?
+            (or (.startsWith ^String content-type "text")
+                (= content-type "application/x-www-form-urlencoded")))
 	(channel-buffer->string body charset)
 	
 	(and auto-transform? (= content-type "application/json"))


### PR DESCRIPTION
This commit fixes the HTTP server transform-netty-body function to convert POST request bodies (content-type application/x-www-form-urlencoded) using channel-buffer->string, instead of the previous fallthrough of channel-buffer->byte-buffers.
