### PR TITLE
Aleph WebSockets

### DIFF
--- a/src/aleph/http/websocket.clj
+++ b/src/aleph/http/websocket.clj
@@ -96,7 +96,8 @@
 	#(assoc %
 	   "upgrade" "WebSocket"
 	   "connection" "Upgrade"))
-      options)))
+      options
+      true)))
 
 (defn- respond-to-handshake [ctx ^HttpRequest request options]
   (let [channel (.getChannel ctx)
@@ -110,7 +111,7 @@
   (let [[inner outer] (channel-pair)
 	close-atom (atom false)
 	close? #(not (compare-and-set! close-atom false true))]
-    
+
     (reify ChannelUpstreamHandler
       (handleUpstream [_ ctx evt]
 
@@ -125,7 +126,7 @@
 		  '(when (close?)
 		    (.close ch)))
 		(enqueue outer (from-websocket-frame msg)))
-	      
+
 	      (instance? HttpRequest msg)
 	      (if (websocket-handshake? msg)
 		(do
@@ -139,7 +140,7 @@
 		  (respond-to-handshake ctx msg options)
 		  (handler inner (assoc (transform-netty-request msg options) :websocket true)))
 		(.sendUpstream ctx evt))))
-	  
+
 	  (if-let [ch (channel-event evt)]
 	    (when-not (.isConnected ch)
 	      (enqueue-and-close inner nil)


### PR DESCRIPTION
Hi there,
      Thank you for very much for authoring Aleph.  I have been working on an html5 w/clojure backend drum machine recently and your Aleph project was a perfect solution.  
       Usually, I prefer Chrome for development but the other day I thought I would investigate the state of WS support in non-webkit browsers and discovered that although Opera and FF claim to support the draft-hixie-thewebsocketprotocol-76 spec, they were not playing nicely with Aleph.  After some poking around, I determine that they were unhappy with the response to the WS handshake.  Specifically, both browsers seem to be pedantic in their implementation of the handshake and are balking when they receive both the "Connection: Upgrade" and "Connection: Close/Keep Alive" pairs.  
      Please review my patch.  It's minimally invasive and just checks for an optional third argument(websocket) in transform-aleph-response.  If websocket is passed in and is true, the Close/Keep Alive Connection status will be not be assoc'd into the response.

Seems to work well with Chrome, Safaria, FF4beta, and Opera 11.

Thanks for the great software!
-Paul Santa Clara
