### PR TITLE
Udp support

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -191,18 +191,22 @@
       nil)))
 
 (defn write-to-channel
-  [^Channel netty-channel msg close? & {close-callback :on-close write-callback :on-write}]
+  [^Channel netty-channel msg close? & {close-callback :on-close write-callback :on-write
+                                        host :host port :port}]
   (when (.isOpen netty-channel)
     (if msg
-      (run-pipeline (io! (.write netty-channel msg))
-	wrap-netty-channel-future
-	(fn [_]
-	  (when write-callback
-	    (write-callback))
-	  (when close?
-	    (close-channel netty-channel close-callback))))
+      (run-pipeline (io!
+                      (if (and host port)
+                        (.write netty-channel msg (InetSocketAddress. host port))
+                        (.write netty-channel msg)))
+                    wrap-netty-channel-future
+                    (fn [_]
+                      (when write-callback
+                        (write-callback))
+                      (when close?
+                        (close-channel netty-channel close-callback))))
       (when close?
-	(close-channel netty-channel close-callback)))))
+        (close-channel netty-channel close-callback)))))
 
 ;;;
 

--- a/src/aleph/udp.clj
+++ b/src/aleph/udp.clj
@@ -1,0 +1,103 @@
+(ns ^{:author "Jeff Rose"}
+  aleph.udp
+  (:use
+    [aleph netty formats]
+    [lamina.core]
+    [gloss core io])
+  (:import
+    [org.jboss.netty.bootstrap ConnectionlessBootstrap]
+    [org.jboss.netty.channel.socket.nio NioDatagramChannelFactory]
+    [org.jboss.netty.handler.codec.serialization ObjectEncoder ObjectDecoder]
+    [org.jboss.netty.channel.socket DatagramChannel]
+    [java.net InetSocketAddress]
+    [org.jboss.netty.channel Channel ChannelPipelineFactory]
+    [org.jboss.netty.handler.codec.string StringDecoder StringEncoder]
+    [org.jboss.netty.util CharsetUtil]
+    [java.net InetAddress InetSocketAddress]))
+
+(defn create-udp-socket
+  "Returns a result-channel that emits a channel if it successfully opens
+  a UDP socket.  Send messages by enqueuing maps containing:
+
+  {:host :port :msg}
+
+  and if bound to a port you can listen by receiving equivalent messages on 
+  the channel returned.
+
+  Optional parameters include:
+    :port <int>     ; to listen on a specific local port and 
+    :broadcast true ; to broadcast from this socket
+    :buf-size <int> ; to set the receive buffer size
+  "
+  [pipeline-fn & {:as options}]
+  (let [{:keys [port broadcast buf-size netty]} (merge {:port 0 
+                                                        :broadcast false
+                                                        :bus-size nil}
+                                                       options)
+        [in-chan out-chan] (channel-pair)
+        client (ConnectionlessBootstrap.
+                 (NioDatagramChannelFactory. client-thread-pool))
+        local-addr (InetSocketAddress. port)
+        netty-opts (if broadcast
+                     (assoc netty "broadcast" true)
+                     netty)
+        nett-opts (if buf-size
+                    (assoc netty-opts "receiveBufferSize" buf-size)
+                    netty-opts)]
+    (.setPipelineFactory client (pipeline-fn out-chan))
+
+    (doseq [[k v] netty-opts]
+      (.setOption client k v))
+
+    (run-pipeline (.bind client local-addr)
+      (fn [netty-chan]
+        (on-closed in-chan
+          (fn []
+            (close-channel netty-chan false)))
+
+        (receive-in-order out-chan
+          (fn [{:keys [host port msg]}]
+            (write-to-channel netty-chan msg false :host host :port port)))
+
+        in-chan))))
+
+(defn udp-message-stage
+  [handler]
+  (upstream-stage
+    (fn [evt]
+      (when-let [msg (message-event evt)]
+        (let [src-addr (event-origin evt)
+              host (.getHostAddress (.getAddress src-addr))
+              port (.getPort src-addr)]
+          (handler msg {:host host :port port}))))))
+
+(defn basic-pipeline-factory
+  [out-chan encoder decoder]
+  (reify ChannelPipelineFactory
+    (getPipeline [_]
+                 (create-netty-pipeline
+                   :encoder encoder
+                   :decoder decoder
+                   :receive (udp-message-stage
+                              (fn [msg addr]
+                                  (enqueue out-chan (assoc addr :msg msg))))))))
+
+(defn create-udp-text-socket
+  [& args]
+  (apply create-udp-socket 
+         #(basic-pipeline-factory %
+           (StringEncoder. CharsetUtil/ISO_8859_1)
+           (StringDecoder. CharsetUtil/ISO_8859_1))
+         args))
+
+(defn create-udp-object-socket
+  [& args]
+  (apply create-udp-socket 
+         #(basic-pipeline-factory %
+           (ObjectEncoder.)
+           (ObjectDecoder.))
+         args))
+
+
+
+

--- a/test/aleph/test/udp.clj
+++ b/test/aleph/test/udp.clj
@@ -1,0 +1,23 @@
+(ns aleph.test.udp
+  (:use
+    [lamina.core]
+    [aleph udp]
+    [clojure.test]
+    [clojure.set :only (difference)]))
+
+(deftest send-recv-test
+  (let [a (wait-for-result (create-udp-object-socket :port 2222))
+        b (wait-for-result (create-udp-object-socket))
+        c (wait-for-result (create-udp-text-socket :port 2223))
+        d (wait-for-result (create-udp-text-socket))
+        msg [{:a 1} "asdf" 23.3]] 
+    (try
+      (enqueue b {:msg msg :host "localhost" :port 2222})
+      (is (= msg (:msg (first (channel-seq a 200)))))
+      (enqueue d {:msg "testing 1, 2, 3" :host "localhost" :port 2223})
+      (is (= "testing 1, 2, 3" (:msg (first (channel-seq c 200)))))
+      (finally
+        (close a)
+        (close b)
+        (close c)
+        (close d)))))


### PR DESCRIPTION
Here's initial support for UDP sockets, as per our email discussion a long time ago.  Included are two pre-configured pipelines for communicating using text or object messages.  The unit test shows basic functionality.   I don't totally grok all the framing stuff in aleph.tcp, so you will probably have thoughts on how to improve the pipeline configuration here.  

In short:

(def a (wait-for-result (create-udp-object-socket :port 2222)))
(def b (wait-for-result (create-udp-object-socket)))
(enqueue b {:msg {:foo "bar"} :host "localhost" :port 2222})
(first (channel-seq a))                      ;   =>          {:msg {:foo "bar"} :host "localhost" :port <wxyz>}
