### PR TITLE
Fix implementation of LazyMap/applyTo to ensure delayed fns are resolved

### DIFF
--- a/src/aleph/core/lazy_map.clj
+++ b/src/aleph/core/lazy_map.clj
@@ -112,7 +112,10 @@
   (invoke [this a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20]
     (throw-lazy-arity 20))
   (applyTo [this args]
-    (apply @m args)))
+    (case (count args)
+      1 (.invoke this (first args))
+      2 (.invoke this (first args) (second args))
+      (throw-lazy-arity (count args)))))
 
 (defn lazy-get
   ([^LazyMap m k]

--- a/test/aleph/test/core/lazy_map.clj
+++ b/test/aleph/test/core/lazy_map.clj
@@ -1,0 +1,36 @@
+;;   Copyright (c) Zachary Tellman. All rights reserved.
+;;   The use and distribution terms for this software are covered by the
+;;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;   which can be found in the file epl-v10.html at the root of this distribution.
+;;   By using this software in any fashion, you are agreeing to be bound by
+;;   the terms of this license.
+;;   You must not remove this notice, or any other, from this software.
+
+(ns aleph.test.core.lazy-map
+  (:use
+   [clojure.test]
+   [aleph.core.lazy-map :only [delayed lazy-map]]))
+
+(defn- mock-delayed
+  [k v]
+  (fn [_] {k v}))
+
+(defn- make-lazy-map
+  []
+  (lazy-map :a 1 :b 2 :c (delayed (mock-delayed :c 3))))
+
+(deftest apply-to-0
+  (is (thrown-with-msg? RuntimeException #"Wrong number of args \(0\) passed to: LazyMap"
+        (apply (make-lazy-map) []))))
+
+(deftest apply-to-1
+  (is (= 3 (apply (make-lazy-map) [:c]))))
+
+(deftest apply-to-2
+  (let [m (make-lazy-map)]
+    (is (= 3 (apply m [:c 4])))
+    (is (= 4 (apply m [:not-in-the-map 4])))))
+
+(deftest apply-to-3
+  (is (thrown-with-msg? RuntimeException #"Wrong number of args \(3\) passed to: LazyMap"
+        (apply (make-lazy-map) [:one :too :many]))))


### PR DESCRIPTION
The last patch had a bug in the implementation of applyTo; it worked fine for normal values, but not delayed values (it returned the delayed function, instead of the result of the delayed function). Amazing the difference lunch makes...
