### PR TITLE
Fixed request-destination to support old (http 1.0) or broken clients which do not include a 'host' header

### DIFF
--- a/src/aleph/http/server/requests.clj
+++ b/src/aleph/http/server/requests.clj
@@ -22,7 +22,7 @@
 (defn- request-destination [_]
   (fn [msg]
     (let [headers (:headers msg)]
-      (let [parts (.split ^String (or (headers "host")) "[:]")]
+      (let [parts (.split ^String (or (headers "host") "") "[:]")]
 	{:server-name (first parts)
 	 :server-port (when-let [port (second parts)]
 			(Integer/parseInt port))}))))


### PR DESCRIPTION
I've noticed that I seem to get a few failed requests per day because this null pointers on the host header; not sure yet if the requests are malicious or just broken clients...
