### PR TITLE
Aleph fails on import-fn in clojure 1.3

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -20,11 +20,11 @@
   (:import
     [java.io InputStream]))
 
-(import-fn server/start-http-server)
-(import-fn client/http-client)
-(import-fn client/pipelined-http-client)
-(import-fn client/http-request)
-(import-fn client/websocket-client)
+(import-fn #'server/start-http-server)
+(import-fn #'client/http-client)
+(import-fn #'client/pipelined-http-client)
+(import-fn #'client/http-request)
+(import-fn #'client/websocket-client)
 
 (defn sync-http-request
   "A synchronous version of http-request.  Halts the thread until the response has returned,
@@ -35,7 +35,7 @@
      (-> (http-request request timeout)
        (wait-for-result timeout))))
 
-(import-fn policy/start-policy-file-server)
+(import-fn #'policy/start-policy-file-server)
 
 (defn wrap-aleph-handler
   "Allows for an asynchronous handler to be used within a largely synchronous application.


### PR DESCRIPTION
Aleph, as well as any other library that uses import-fn, fails in clojure 1.3

Passing a var instead of a symbol fixes this issue.
