### PR TITLE
add cons implementation for aleph.core.lazy-map

### DIFF
--- a/src/aleph/core/lazy_map.clj
+++ b/src/aleph/core/lazy_map.clj
@@ -6,7 +6,9 @@
 ;;   the terms of this license.
 ;;   You must not remove this notice, or any other, from this software.
 
-(ns aleph.core.lazy-map)
+(ns aleph.core.lazy-map
+  (:import java.util.Map$Entry)
+  (:import clojure.lang.IPersistentVector))
 
 (defmacro delayed [f]
   `(let [f# ~f]
@@ -28,6 +30,14 @@
     (and
       (map? x)
       (= x (into {} this))))
+  (cons [this o]
+    (cond
+      (instance? Map$Entry o)
+        (let [[a b] o] (assoc this a b))
+      (instance? IPersistentVector o)
+        (do (assert (= 2 (count o))) (let [[a b] o] (assoc this a b)))
+      :else
+        (reduce conj this o)))
   clojure.lang.Counted
   (count [this]
     (count (seq this)))

--- a/test/aleph/test/core/lazy_map.clj
+++ b/test/aleph/test/core/lazy_map.clj
@@ -34,3 +34,9 @@
 (deftest apply-to-3
   (is (thrown-with-msg? RuntimeException #"Wrong number of args \(3\) passed to: LazyMap"
         (apply (make-lazy-map) [:one :too :many]))))
+
+(deftest conj-test
+  (is (conj (make-lazy-map) [3 4])))
+
+(deftest merge-test
+  (is (= :bar (:foo (merge (make-lazy-map) {:foo :bar})))))


### PR DESCRIPTION
I ran into an issue because I thought the request object passed in to my http function was a regular map and I could treat it like one. Turns out it fails on conj and merge, which is fixed by implementing IPersistentMap#cons. I implemented it in terms of assoc, trying to avoid actually having to figure out how the lazy-map works generally.
