### PR TITLE
fix to avoid spawning one thread per (client-)connection

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -431,11 +431,9 @@
 (defn get-nio-channel-factory
   "NioClientSocketChannelFactory singleton"
   []
-  (or
-    @nio-channel-factory
-    (reset! nio-channel-factory (NioClientSocketChannelFactory.
-	    (Executors/newCachedThreadPool)
-	    (Executors/newCachedThreadPool)))))
+  (swap! nio-channel-factory #(or % (NioClientSocketChannelFactory. 
+                                      (Executors/newCachedThreadPool)
+                                      (Executors/newCachedThreadPool)))))
 
 (defn create-client
   [pipeline-fn send-encoder options]


### PR DESCRIPTION
Hello Zach,

I use the http client of Aleph to fetch web pages. During a bunch of tests with a thousand of concurrent connections, I was very surprised to see that the number of threads increased very quickly. For example, with thousand concurrent connections, the number of threads hited almost a thousand! That's not the behavior I expected with Netty's asynchronous IOs.

After a small investigation, I noticed that netty/create-client create a NioClientSocketChannelFactory for every connections, therefore every connection use its own thread (pool of threads) and we loose the power of Netty.

I just patched Aleph to reuse the same NioClientSocketChannelFactory for every connections. Like this, with the same benchmark, number of threads is stable at about 30.

David
