### PR TITLE
fix channels closing issue

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -508,9 +508,6 @@
 			    netty-channel
 			    #(write-to-channel netty-channel nil true))]
           
-	  (run-pipeline (.getCloseFuture netty-channel)
-	    wrap-netty-channel-future
-	    )
 	  (.add channel-group netty-channel)
           
 	  (receive-all outer


### PR DESCRIPTION
Hello Zach,

I found a strange behavior in the http client when chunked responses are received. The last chunks of the response are lost when the connection is closed, so the body is corrupted and unusable.

Here's a small example with the Youtube API. In this case, the response is composed by two chunks but they are both lost, so body is null.

``` clojure
  @(http/http-request {:method :get :url "http://www.youtube.com/oembed?url=http%3A//youtube.com/watch%3Fv%3DM3r2XDceM6A&format=json" :auto-transform true})
```

After a while, I found that you rely on the close future of the netty channel to closes lamina channels (netty.clj:470). In this case, it's better to rely on channelDisconnected event. The close future is always notified before an event is fired into a pipeline, and a decoder can delay the immediate propagation of the channelDisconnected event if there is any remaining data to decode in its internal buffer.

I just patched Aleph to rely on the event instead of the future and it works fine now. What do you think about the way I choose to handle this case?

David
