### PR TITLE
Fix for one of multiple issues with WebSockets connections using firefox 8 and up

### DIFF
--- a/src/aleph/http/websocket.clj
+++ b/src/aleph/http/websocket.clj
@@ -35,10 +35,10 @@
 
 
 (defn websocket-handshake? [^HttpRequest request]
-  (let [connection-header (.getHeader request "connection") ]
-    (and connection-header
-         (= "upgrade" (.toLowerCase connection-header))
-         (= "websocket" (.toLowerCase (.getHeader request "upgrade"))))))
+  (when-let [connection-header (.toLowerCase (.getHeader request "connection")) ]
+    (let [connection-params (set (clojure.string/split connection-header #", ")) ]
+           (and (contains? connection-params "upgrade")
+                (= "websocket" (.toLowerCase (.getHeader request "upgrade")))))))
 
 (defn hybi? [^HttpRequest request]
   (.containsHeader request "Sec-WebSocket-Version"))


### PR DESCRIPTION
The first problem is that firefox WebSocket connections are being interpreted as normal HTTP connections. This is because the connection header can contain multiple comma separated values including the "Upgrade" token. This is the case with firefox 8 and 9 which also send "keep-alive" in the connection header. In other words it looks like this in firefox:

```
Connection: keep-alive, Upgrade
```

This pull fixes that issue. I've verified that firefox now connects successfully.

However, shortly after connected, the onerror handler fires and the connection is closed. I've instrumented the server with the following:

```
--- a/src/aleph/http/websocket/protocol.clj
+++ b/src/aleph/http/websocket/protocol.clj
@@ -108,6 +108,7 @@
        %)))

 (defn post-process-frame [frame]
+  (prn "Received websockets frame: " frame)
   (case (:type frame)
     :binary (:data frame)
     :text (bytes->string (:data frame))
```

With that debug, both Chrome and firefox print the following immediately after connecting:

```
"Received websockets frame: " {:data nil}
```

If I send a test message from Chrome, I see something like this:

```
"Received websockets frame: " {:data (#<HeapByteBuffer java.nio.HeapByteBuffer[pos=0 lim=4 cap=4]>), :mask 188699892}
```

It seems to me that there should be more keys in the frame that just :data and :mask, especially since immediately after than prn, the :type key is looked up. It's possible that firefox is immediately sending a frame with an opcode other than text and expecting a response. Although the disconnect happens less than 100ms after the connect which is faster than I would expect for a timeout

Thanks for looking into this.
