### PR TITLE
Upgrade to clojure 1.4 and a bug fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,12 +5,11 @@
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
-  :dependencies [[org.clojure/clojure "1.3.0"]
+  :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/tools.logging "0.2.3"]
                  [io.netty/netty "3.3.1.Final"]
                  [lamina "0.5.0-SNAPSHOT"]
                  [gloss "0.2.2-SNAPSHOT"]
-                 [potemkin "0.1.2"]
                  [clj-json "0.5.0"]
                  [prxml "1.3.1"]]
   :dev-dependencies [[criterium "0.2.1-SNAPSHOT"]

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -36,7 +36,7 @@
       ;; transform body
       (if (options/streaming-ring-requests?)
         identity
-        (fn [{:keys [body] :as request}]
+        (fn [{:keys [body character-encoding] :as request}]
 
           ;; if it's a streaming request, wait for it to complete
           (if (channel? body)
@@ -46,9 +46,11 @@
                 (if (channel? body)
                   (reduce* conj [] body)
                   body))
-              #(update-in request [:body]
-                 (formats/bytes->input-stream %)))
-            request)))
+              #(assoc request
+                 :body
+                 (formats/bytes->input-stream % character-encoding)))
+            (update-in request [:body]
+                       formats/bytes->input-stream character-encoding))))
 
       ;; call into handler
       (fn [request]


### PR DESCRIPTION
removed explict dependency on potemkin (use the transitive dependency through
lamina).

changed wrap-ring-handler to convert body to an input stream even when
the request is not streaming
