### PR TITLE
use https in the twitter streaming example

### DIFF
--- a/test/aleph/example/twitter.clj
+++ b/test/aleph/example/twitter.clj
@@ -25,7 +25,7 @@
 		    (sync-http-request
 		      {:method :get
 		       :basic-auth [username password]
-		       :url "http://stream.twitter.com/1/statuses/sample.json"
+		       :url "https://stream.twitter.com/1/statuses/sample.json"
 		       :delimiters ["\r"]
 		       }))]
        (Thread/sleep duration)
@@ -40,7 +40,7 @@
       (http-request 
 	{:method :get 
 	 :basic-auth ["aleph_example" "_password"]
-	 :url "http://stream.twitter.com/1/statuses/sample.json"}))))
+	 :url "https://stream.twitter.com/1/statuses/sample.json"}))))
 
 (defn init-stream-channel [ch]
   ;; we need a sink for messages, since we always fork the original channel
@@ -50,7 +50,7 @@
     (let [response (http-request 
 		     {:method :get 
 		      :basic-auth ["aleph_example" "_password"]
-		      :url "http://stream.twitter.com/1/statuses/sample.json"
+		      :url "https://stream.twitter.com/1/statuses/sample.json"
 		      :delimiters ["\r"]})]
       (siphon (:body response) ch))))
 


### PR DESCRIPTION
Back last September, the Twitter streaming API became [HTTPS only](https://github.com/ztellman/aleph/pull/36#issuecomment-2239127), and the URLs in the aleph readme got updated... but not the example source code, or the wiki page got changed. I've changed the wiki, and this is just for the example source.
