### PR TITLE
Expose the breaklines parameter of Netty's Base64/encode call.

### DIFF
--- a/src/aleph/formats.clj
+++ b/src/aleph/formats.clj
@@ -278,9 +278,11 @@
 
 (defn base64-encode
   "Encodes the data into a base64 string representation."
-  [data]
-  (when data
-    (-> data to-channel-buffer Base64/encode channel-buffer->string)))
+  ([data]
+     (base64-encode data true))
+  ([data ^Boolean breaklines]
+     (when data
+       (-> data to-channel-buffer (Base64/encode breaklines) channel-buffer->string))))
 
 (defn base64-decode
   "Decodes a base64 encoded string into bytes."


### PR DESCRIPTION
The current implementation of aleph.formats/base64-encode is injecting "\n" into the data every 77 chars.  This is because the underlying encoder does this by default.  I added an optional parameter to the base64-encode function to enable users to turn that off. In order to not break current code, it still defaults to on, but I think it should default to off.  Also, since I don't know which "dialect" (see the Netty documentation) is the default, I didn't expose it as a parameter to base64-encode.
