### PR TITLE
Make `rfc-1123-date-string` use GMT rather than the local time zone

### DIFF
--- a/src/aleph/netty/core.clj
+++ b/src/aleph/netty/core.clj
@@ -18,6 +18,7 @@
      DateFormat
      SimpleDateFormat]
     [java.util
+     TimeZone
      Date]
     [org.jboss.netty.buffer
      ChannelBuffer]
@@ -82,6 +83,7 @@
         (or
           (.get date-format)
           (let [format (SimpleDateFormat. "EEE, dd MMM yyyy HH:mm:ss z")]
+            (.setTimeZone format (TimeZone/getTimeZone "GMT"))
             (.set date-format format)
             format))]
     (.format format (Date.))))


### PR DESCRIPTION
HTTP 1.1 mandates that "date/time stamps MUST be represented in
Greenwich Mean Time (GMT), without exception" (section 3.1.1). This
function is only used by the HTTP server component right now but it's
generally a good idea to use GMT in RFC 1123 timestamps anyway.
