### PR TITLE
Added pipeline-transform to netty sub-options.

### DIFF
--- a/src/aleph/http/netty.clj
+++ b/src/aleph/http/netty.clj
@@ -110,6 +110,7 @@
           (when (options/websocket? options)
             (.addBefore pipeline "handler" "websocket"
               (ws/server-handshake-stage handler)))
+          ((get netty-options "pipeline-transform" identity) pipeline)
           pipeline))
       options)))
 


### PR DESCRIPTION
This commit adds an option called "pipeline-transform" to the netty sub-option map in aleph.http.netty/start-http-server.  Within start-http-server the pipeline is constructed exactly as before, however just before it is returned, the pipeline-transform function is invoked with the pipeline as the sole argument.  If no pipeline-transform function is provided, the identity function is used as a default.  This allows for modification of the server pipeline without modification to Aleph code, for example, enabling SSL via a pipeline-transform function which adds a Netty SslHandler to the front of the pipeline.
