### PR TITLE
Use uppercased HTTP methods in Ring method map

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -54,7 +54,7 @@
 
 (def netty-method->keyword
   (zipmap
-    (map #(HttpMethod/valueOf (name %)) request-methods)
+    (map #(HttpMethod/valueOf (.toUpperCase (name %))) request-methods)
     request-methods))
 
 (def keyword->netty-method


### PR DESCRIPTION
Since the patch for [this Netty
issue](https://github.com/netty/netty/issues/702) was applied and
included in Netty 3.5.10.Final, Aleph wouldn't recognize RFC 2068
compliant HTTP methods anymore because netty-method->keyword only mapped
lowercased versions of them to the corresponding Ring keywords. The
Netty patch is correct as section 5.1.1 of RFC 2068 specifies HTTP
methods to be case-sensitive and defines all existing methods as
uppercased. Ths patch addresses this change and makes Aleph recognize
those methods again.
