### PR TITLE
make udp broadcast work as expected

### DIFF
--- a/src/aleph/netty/udp.clj
+++ b/src/aleph/netty/udp.clj
@@ -97,14 +97,14 @@
 
   (let [[a b] (channel-pair)
         client (ConnectionlessBootstrap. @channel-factory)
-        {:keys [port broadcast? buf-size]
+        {:keys [port broadcast buf-size]
          :or {port 0
               buf-size 16384}} options
         netty-options (-> options
                         :netty
                         :options
                         (update-in ["broadcast"]
-                          #(or % broadcast?))
+                          #(or % broadcast))
                         (update-in ["receiveBufferSize"]
                           #(or % buf-size))
                         (update-in ["sendBufferSize"]

--- a/test/aleph/test/udp.clj
+++ b/test/aleph/test/udp.clj
@@ -20,6 +20,7 @@
         c @(udp-socket {:frame (string :utf-8) :port 2223})
         d @(udp-socket {:frame (string :utf-8)})
         e @(udp-socket)
+        g @(udp-socket {:broadcast true})
         object-msg [{:a 1} "asdf" 23.3]
 	text-msg (->> "a" (repeat 1e3) (apply str))] 
     (try
@@ -29,10 +30,13 @@
       (is (= text-msg (:message (wait-for-message c 2000))))
       (enqueue e {:message text-msg :host "localhost" :port 2223})
       (is (= text-msg (:message (wait-for-message c 2000))))
+      (enqueue g {:message text-msg :host "255.255.255.255" :port 2223})
+      (is (= text-msg (:message (wait-for-message c 2000))))
       (finally
         (close b)
         (close d)
         (close e)
+        (close g)
         (close a)
         (close c)))))
 


### PR DESCRIPTION
The broadcast property is not enabled when specifying 

``` clojure
(udp-socket {:broadcast true})
```

There is a tiny mismatch between the documentation and code. 

``` clojure
{:keys [port broadcast? buf-size]
         :or {port 0
              buf-size 16384}} options
```

An alternative solution would be to update the doc so it says 'broadcast?' rather than 'broadcast'. 

Ex:

``` clojure
(udp-socket {:broadcast? true})
```
