### PR TITLE
add a option to send custom headers on websocket client handshake

### DIFF
--- a/src/aleph/formats.clj
+++ b/src/aleph/formats.clj
@@ -514,3 +514,10 @@
         (decode-channel decoder ch)
         ch)
       ch*)))
+
+(defn keyword-map->string-map
+  [headers]
+  (apply hash-map
+         (flatten
+          (map (fn [[k v]] [(name k) (str v)]) (apply list headers)))))
+

--- a/src/aleph/http/websocket.clj
+++ b/src/aleph/http/websocket.clj
@@ -147,7 +147,7 @@
 
 ;;;
 
-(defn client-handshake-stage [result url]
+(defn client-handshake-stage [result url custom-headers]
   (let [handshake-latch (atom false)
         response-latch (atom false)
         handshaker (.newHandshaker
@@ -156,7 +156,7 @@
                      WebSocketVersion/V13
                      nil
                      false
-                     nil)]
+                     (java.util.HashMap. (formats/keyword-map->string-map custom-headers)))]
     (reify ChannelUpstreamHandler
       (handleUpstream [_ ctx evt]
         (let [netty-channel (.getChannel evt)]
@@ -199,7 +199,8 @@
               :decoder (HttpResponseDecoder.)
               :handshaker (client-handshake-stage
                             result
-                            (java.net.URI. (client/options->url options)))))
+                            (java.net.URI. (client/options->url options))
+                            (:custom-headers options))))
           options))
       #(merge-results result %)
       second


### PR DESCRIPTION
I added a option to send custom headers on a WebSocket client handshake.
It's useful for client authentication.
