### PR TITLE
Allow Content-Length overriding

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -353,7 +353,9 @@
                          encode)
                        (encode body))]
             (.setContent msg body))
-          (HttpHeaders/setContentLength msg (.readableBytes (.getContent msg))))
+          (HttpHeaders/setContentLength msg
+           (or (http-content-length msg)
+               (.readableBytes (.getContent msg)))))
         {:msg msg}))))
 
 (defn valid-ring-response? [rsp]


### PR DESCRIPTION
I'm implementing a protocol where HEAD requests are used to
provide details about resources and which uses 'Content-Length'
to provide the resource's size.

With aleph it is currently impossible to implement it since the
'Content-Length' header is always inferred from the payload being
sent.

This patch allows overriding the header when it was explicitly
set in the response and only for non channel or reader bodies.
