### PR TITLE
For 204 response the body should be empty...

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -539,7 +539,7 @@
   (fn [req]
     (-> (client req)
         (d/chain' (fn [resp]
-                    (if (and (= 204 (:status resp)) (= 0 (.available (:body resp))))
+                    (if (and (= 204 (:status resp)) (= 0 (.available ^InputStream (:body resp))))
                       (dissoc resp :body)
                       resp))))))
 


### PR DESCRIPTION
...not an empty ByteArrayInputStream.

When proxying through the server a body here will result in a
`Transfer-Encoding:chunked` in the aleph server, basically stating the body size
is unknown. Some caching products, like varnish, fails miserably here, e.g. gives
the calling client back an http 503.

With this change, at least when the body is empty it is removed, and the
`Transfer-Encoding:chunked` is not added.


This seems to be working. I guess there is a deeper root cause here, somewhere in Netty perhaps? I would be happy to change this in any way you'd like, or attack the problem differently. Let me know.

Cheers,
Alf