### PR TITLE
[client] Don't close connections when HttpObjectAggregator is on the pipeline

### DIFF
--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -195,13 +195,9 @@
           (instance? FullHttpResponse msg)
           (let [^FullHttpResponse rsp msg
                 content (.content rsp)
-                c (d/deferred)
-                s (netty/buffered-source (netty/channel ctx) #(alength ^bytes %) buffer-capacity)]
-            (s/on-closed s #(d/success! c true))
-            (s/put! s (netty/buf->array content))
+                body (netty/buf->array content)]
             (netty/release content)
-            (handle-response rsp c s)
-            (s/close! s))
+            (handle-response rsp (d/success-deferred false) body))
 
           (instance? HttpResponse msg)
           (let [rsp msg]


### PR DESCRIPTION
This is a fix to #393 by @rborer. `(s/on-closed s #(d/success! c true))` means that the request was completed `early?` which leads to a connection being disposed from the pool rather than released back to it ([this](https://github.com/ztellman/aleph/blob/master/src/aleph/http.clj#L343)). I guess, this is not intentional and just copy-n-paste error. We also don't need to create a stream because the aggregator already waited for the whole response and aggregated it for us. 