### PR TITLE
Customizable error handler

### DIFF
--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -469,7 +469,7 @@
   (with-handler invalid-handler
     (let [{:keys [body status]} @(http-get (apply str "http://localhost:" port  "/invalid"))]
       (is (= 500 status))
-      (is (re-find #"java\.lang\.IllegalArgumentException: code: -100 \(expected: >= 0\)"
+      (is (re-find #"java\.lang\.IllegalArgumentException: code : -100 \(expected: >= 0\)"
                    (bs/to-string body)))))
   (testing "custom error handler"
     (with-server (http/start-server invalid-handler


### PR DESCRIPTION
Hey.

In case of any unhandled exception, the current behavior is print whole stracktrace into response's body. It's not what we want and there is no way to alter this behavior currently.

This PR adds new configuration option `:error-handler` to http server, this handler is called for unhandled exceptions inside HTTP machinery. By default, it's old `error-response`.