### PR TITLE
Upgrade to Netty 4.1.49.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.36.Final")
+(def netty-version "4.1.49.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
Changelogs from 4.1.36:
- https://netty.io/news/2019/06/28/4-1-37-Final.html
- https://netty.io/news/2019/07/24/4-1-38-Final.html
- https://netty.io/news/2019/08/13/4-1-39-Final.html
- https://netty.io/news/2019/09/12/4-1-41-Final.html
- https://netty.io/news/2019/09/25/4-1-42-Final.html
- https://netty.io/news/2019/10/24/4-1-43-Final.html
- https://netty.io/news/2019/12/18/4-1-44-Final.html
- https://netty.io/news/2020/01/13/4-1-45-Final.html
- https://netty.io/news/2020/02/28/4-1-46-Final.html
- https://netty.io/news/2020/03/09/4-1-47-Final.html
- https://netty.io/news/2020/03/17/4-1-48-Final.html
- https://netty.io/news/2020/04/22/4-1-49-Final.html