### PR TITLE
Upgrade to Netty 4.1.50.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.36.Final")
+(def netty-version "4.1.50.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
The update netty ver 4.1.50 includes both security fixes and AArch64 performance improvements

Signed-off-by: odidev <odidev@puresoftware.com>