### PR TITLE
Error handling, revisited

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -54,7 +54,8 @@
    | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds
    | `continue-handler` | optional handler which is invoked when header sends \"Except: 100-continue\" header to test whether the request should be accepted or rejected. Handler should return `true`, `false`, ring responseo to be used as a reject response or deferred that yields one of those.
    | `continue-executor` | optional `java.util.concurrent.Executor` which is used to handle requests passed to :continue-handler.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread.
-   | `num-event-loop-threads` | optional, defaults to double number of available processors."
+   | `num-event-loop-threads` | optional, defaults to double number of available processors.
+   | `error-logger` | optional, function to be invoked on each exception propagated through the pipeline up to `request-handler`. Supposed to be used only for logging, crash reporting, metrics, etc rather than error recovery."
   [handler options]
   (when (contains? options :max-chunk-size)
     (log/warn "Ignoring :max-chunk-size option as it was deprecated"))

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -270,7 +270,8 @@
    | `max-frame-payload` | maximum allowable frame payload length, in bytes, defaults to `65536`.
    | `max-frame-size` | maximum aggregate message size, in bytes, defaults to `1048576`.
    | `allow-extensions?` | if true, allows extensions to the WebSocket protocol, defaults to `false`.
-   | `heartbeats` | optional configuration to send Ping frames to the client periodically (if the connection is idle), configuration keys are `:send-after-idle` (in milliseconds), `:payload` (optional, empty uses empty frame by default) and `:timeout` (optional, to close the connection if Pong is not received after specified timeout)."
+   | `heartbeats` | optional configuration to send Ping frames to the client periodically (if the connection is idle), configuration keys are `:send-after-idle` (in milliseconds), `:payload` (optional, empty uses empty frame by default) and `:timeout` (optional, to close the connection if Pong is not received after specified timeout).
+   | `error-logger` | optional, function to be invoked on each exception propagated through the pipeline up to `request-handler`. Supposed to be used only for logging, crash reporting, metrics, etc rather than error recovery."
   ([req]
     (websocket-connection req nil))
   ([req options]

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -404,8 +404,8 @@
                                            (flow/dispose pool k conn)
                                            (flow/release pool k conn)))))
                                    (-> rsp
-                                     (dissoc :aleph/complete)
-                                     (assoc :connection-time (- end start)))))))))
+                                       http-core/wrap-complete
+                                       (assoc :connection-time (- end start)))))))))
 
                        (fn [rsp]
                          (->> rsp

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -133,7 +133,8 @@
    | `log-activity` | when set, logs all events on each channel (connection) with a log level given. Accepts either one of `:trace`, `:debug`, `:info`, `:warn`, `:error` or an instance of `io.netty.handler.logging.LogLevel`. Note, that this setting *does not* enforce any changes to the logging configuration (default configuration is `INFO`, so you won't see any `DEBUG` or `TRACE` level messages, unless configured explicitly)
    | `decompress-body?` | when set to `true`, automatically decompresses the resulting gzip or deflate stream if the `Content-Encoding` header is found on the response, defaults to `false`
    | `save-content-encoding?` | set to `true` to get information about Content-Encoding of the response before decompression, defaults to `false`
-
+   | `error-logger` | optional, function to be invoked on each exception propagated through the pipeline up to `client-handler`. Supposed to be used only for logging, crash reporting, metrics, etc rather than error recovery
+   
    Supported `proxy-options` are
 
    |:---|:---
@@ -240,6 +241,7 @@
    | `heartbeats` | optional configuration to send Ping frames to the server periodically (if the connection is idle), configuration keys are `:send-after-idle` (in milliseconds), `:payload` (optional, empty frame by default) and `:timeout` (optional, to close the connection if Pong is not received after specified timeout).
    | `name-resolver` | specify the mechanism to resolve the address of the unresolved named address. When not set or equals to `:default`, JDK's built-in domain name lookup mechanism is used (blocking). Set to`:noop` not to resolve addresses or pass an instance of `io.netty.resolver.AddressResolverGroup` you need.
    | `proxy-options` | a map to specify proxy settings. HTTP, SOCKS4 and SOCKS5 proxies are supported. Note, that when using proxy `connections-per-host` configuration is still applied to the target host disregarding tunneling settings. If you need to limit number of connections to the proxy itself use `total-connections` setting.
+   | `error-logger` | optional, function to be invoked on each exception propagated through the pipeline up to `client-handler`. Supposed to be used only for logging, crash reporting, metrics, etc rather than error recovery
 
    Supported `proxy-options` are
 

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -663,8 +663,8 @@
 
               ;; this will usually happen because of a malformed request
               (catch Throwable e
-                (netty/close ch)
-                (s/put! responses (d/error-deferred e)))))
+                (s/put! responses (d/error-deferred e))
+                (netty/close ch))))
           requests)
 
         (s/on-closed responses

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -266,7 +266,7 @@
                 ;; xxx(okachaiev): what exactly we gonna do when the stream
                 ;; is present??? discard the rest of the content? close the stream?
                 ;; xxx(okachaiev): interesting fact, closing the connection here
-                ;; would lead to ClosedChannelException on the server side
+                ;; would lead to `ClosedChannelException` on the server side
                 (s/close! s)
                 (handle-decoder-failure ctx msg response-stream)))
             (let [content (.content ^HttpContent msg)]

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -21,14 +21,12 @@
     [io.netty.handler.codec.http
      HttpClientCodec
      DefaultHttpHeaders
-     HttpHeaders
      HttpRequest
      HttpResponse
      HttpContent
      HttpUtil
      HttpHeaderNames
      LastHttpContent
-     FullHttpRequest
      FullHttpResponse
      HttpObjectAggregator
      HttpContentDecompressor]
@@ -36,15 +34,11 @@
      Channel
      ChannelHandler ChannelHandlerContext
      ChannelPipeline]
-    [io.netty.handler.codec
-     TooLongFrameException]
     [io.netty.handler.timeout
      IdleState
      IdleStateEvent]
     [io.netty.handler.stream
      ChunkedWriteHandler]
-    [io.netty.handler.codec.http
-     FullHttpRequest]
     [io.netty.handler.codec.http.websocketx
      CloseWebSocketFrame
      PingWebSocketFrame
@@ -67,14 +61,12 @@
      Socks4ProxyHandler
      Socks5ProxyHandler]
     [io.netty.handler.logging
-     LoggingHandler
-     LogLevel]
+     LoggingHandler]
     [io.netty.util.concurrent
      EventExecutor
      ScheduledFuture]
     [java.util.concurrent
      ConcurrentLinkedQueue
-     Future
      TimeUnit]
     [java.util.concurrent.atomic
      AtomicInteger

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -619,12 +619,12 @@
                   ;; writes (e.g. chunked body)
                   (-> (netty/safe-execute ch
                         (http/send-message ch true ssl? req' body))
-                      (d/catch' Throwable
-                                (fn [e]
-                                  ;; this might happen if request processing failed
-                                  ;; being offloaded onto netty's event loop
-                                  (s/put! responses (d/error-deferred e))
-                                  (netty/close ch))))))
+                      (d/catch'
+                        (fn [^Throwable e]
+                          ;; this might happen if request processing failed
+                          ;; being offloaded onto netty's event loop
+                          (s/put! responses (d/error-deferred e))
+                          (netty/close ch))))))
 
               ;; this will usually happen because of a malformed request
               (catch Throwable e

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -112,13 +112,13 @@
 
 (defn handle-exception [^ChannelHandlerContext ctx ^Throwable ex response-stream error-logger]
   ;; Typical non-IO exception would be TooLongFrameException, SSLHandshakeError etc
-  (when-not (not (instance? IOException ex))
-    (try
-      (error-logger ex)
-      (catch Throwable e
-        (log/warn "error in error logger" e)))
+  (when-not (instance? IOException ex)
+   (try
+     (error-logger ex)
+     (catch Throwable e
+       (log/warn "error in error logger" e)))
     ;; An exception might happen while realizing async body from the response
-    ;; (the message from `response-stream` is arelady taken by the user).
+    ;; (the message from `response-stream` is already taken by the user).
     ;; In this case, offering a new one item in the response stream would mean
     ;; we are enqueuing response for the next request over the same connection.
     ;; Which effectively means that we MUST close the connection when

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -123,7 +123,8 @@
 ;; response to the next request over the same connection)
 (defn handle-exception [ctx ex response-stream]
   (cond
-    ;; could happens when io.netty.handler.codec.http.HttpObjectAggregator
+    ;; could happens when the response message violates `MAX_INITIAL_LINE_LENGTH` or
+    ;; `MAX_HEADER_SIZE` or when `io.netty.handler.codec.http.HttpObjectAggregator`
     ;; is part of the pipeline
     (instance? TooLongFrameException ex)
     (s/put! response-stream ex)

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -28,8 +28,11 @@
      DecoderResult
      DecoderResultProvider]
     [io.netty.handler.codec.http
-     DefaultHttpRequest DefaultLastHttpContent
-     DefaultHttpResponse DefaultFullHttpRequest
+     DefaultHttpRequest
+     DefaultLastHttpContent
+     DefaultHttpResponse
+     DefaultFullHttpRequest
+     DefaultFullHttpResponse
      FullHttpRequest
      HttpHeaders HttpUtil HttpContent
      HttpMethod HttpRequest HttpMessage
@@ -182,6 +185,18 @@
               HttpVersion/HTTP_1_1
               (HttpResponseStatus/valueOf status)
               false)]
+    (when headers
+      (map->headers! (.headers rsp) headers))
+    rsp))
+
+(defn ring-response->full-netty-response [{:keys [status headers body]}]
+  (let [^HttpResponseStatus status (if (instance? HttpResponseStatus status)
+                                     status
+                                     (HttpResponseStatus/valueOf status))
+        rsp (DefaultFullHttpResponse.
+             HttpVersion/HTTP_1_1
+             status
+             ^ByteBuf (netty/to-byte-buf body))]
     (when headers
       (map->headers! (.headers rsp) headers))
     rsp))

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -575,7 +575,10 @@
                 (let [class-name (.getName (class body))]
                   (log/errorf "error sending body of type %s: %s"
                               class-name
-                              (.getMessage ^Throwable e)))
+                              (.getMessage ^Throwable e))
+                  ;; re-throw exception so the caller could take care
+                  ;; about cleaning up the mess
+                  (throw e))
                 ;; xxx(errors-handling): this is actually might be wrong
                 ;; there's a non-zero chance we've already sent msg and
                 ;; failed when started sending body

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -575,6 +575,12 @@
                   (log/errorf "error sending body of type %s: %s"
                               class-name
                               (.getMessage ^Throwable e))
+                  ;; duplicating logic from `handle-cleanup` as
+                  ;; we will never got there. the implementation guarantees
+                  ;; that non persistent connection would be closed
+                  ;; in any case
+                  (when-not keep-alive?
+                    (netty/close ch))
                   ;; re-throw exception so the caller could take care
                   ;; about cleaning up the mess
                   (throw e))))]

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -32,8 +32,6 @@
      DefaultLastHttpContent
      DefaultHttpResponse
      DefaultFullHttpRequest
-     DefaultFullHttpResponse
-     FullHttpRequest
      HttpHeaders HttpUtil HttpContent
      HttpMethod HttpRequest HttpMessage
      HttpResponse HttpResponseStatus
@@ -53,8 +51,7 @@
      PingWebSocketFrame
      TextWebSocketFrame
      BinaryWebSocketFrame
-     CloseWebSocketFrame
-     WebSocketChunkedInput]
+     CloseWebSocketFrame]
     [java.io
      File
      RandomAccessFile

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -261,6 +261,17 @@
 (defn ring-request-ssl-session [^NettyRequest req]
   (netty/channel-ssl-session (.ch req)))
 
+(defn wrap-complete [rsp]
+  (let [prev-flag (:aleph/complete rsp)
+        new-flag (if (nil? prev-flag)
+                   (d/success-deferred false)
+                   (let [d' (d/deferred)]
+                     (d/connect prev-flag d')
+                     d'))]
+    (-> rsp
+        (dissoc :aleph/complete)
+        (assoc :aleph/interrupted? new-flag))))
+
 ;;;
 
 (defn has-content-length? [^HttpMessage msg]

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -580,7 +580,7 @@
           (try
             (error-logger e)
             (catch Throwable ex
-              (log/error "error in error logger" e))))
+              (log/error ex "error in error logger"))))
         ;; duplicating logic from `handle-cleanup` as
         ;; we will never got there. the implementation guarantees
         ;; that non persistent connection would be closed

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -189,18 +189,6 @@
       (map->headers! (.headers rsp) headers))
     rsp))
 
-(defn ring-response->full-netty-response [{:keys [status headers body]}]
-  (let [^HttpResponseStatus status (if (instance? HttpResponseStatus status)
-                                     status
-                                     (HttpResponseStatus/valueOf status))
-        rsp (DefaultFullHttpResponse.
-             HttpVersion/HTTP_1_1
-             status
-             ^ByteBuf (netty/to-byte-buf body))]
-    (when headers
-      (map->headers! (.headers rsp) headers))
-    rsp))
-
 (defn ring-request->netty-request [m]
   (let [headers (get m :headers)
         req (DefaultHttpRequest.

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -23,7 +23,10 @@
      ByteBuf]
     [java.nio
      ByteBuffer]
-    [io.netty.handler.codec DecoderException]
+    [io.netty.handler.codec
+     DecoderException
+     DecoderResult
+     DecoderResultProvider]
     [io.netty.handler.codec.http
      DefaultHttpRequest DefaultLastHttpContent
      DefaultHttpResponse DefaultFullHttpRequest
@@ -284,11 +287,22 @@
    :headers {"content-type" "text/plain"}
    :body "Internal server error"})
 
+(def default-unavailable-response
+  {:status 503
+   :headers {"content-type" "text/plain"}
+   :body "503 Service Unavailable"})
+
 ;; Logs exception and returns default 500 response
 ;; not to expose internal logic to the client
 (defn error-response [^Throwable e]
   (log/error e "error in HTTP handler")
   default-error-response)
+
+(defn decoder-failed? [^DecoderResultProvider msg]
+  (.isFailure ^DecoderResult (.decoderResult msg)))
+
+(defn ^Throwable decoder-failure [^DecoderResultProvider msg]
+  (.cause ^DecoderResult (.decoderResult msg)))
 
 (defn send-streaming-body [ch ^HttpMessage msg body]
 

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -245,17 +245,20 @@
   :aleph/complete complete
   :body body)
 
-(defn netty-request->ring-request [^HttpRequest req ssl? ch body interrupted?]
-  (let [req' (-> (->NettyRequest
-                  req
-                  ssl?
-                  ch
-                  (AtomicBoolean. false)
-                  (-> req .uri (.indexOf (int 63))) body)
-                 (assoc :aleph/request-arrived (System/nanoTime)))]
-    (if (nil? interrupted?)
-      req'
-      (assoc req' :aleph/interrupted? interrupted?))))
+(defn netty-request->ring-request
+  ([req ssl? ch body]
+   netty-request->ring-request req ssl? ch body nil)
+  ([^HttpRequest req ssl? ch body interrupted?]
+   (let [req' (-> (->NettyRequest
+                   req
+                   ssl?
+                   ch
+                   (AtomicBoolean. false)
+                   (-> req .uri (.indexOf (int 63))) body)
+                  (assoc :aleph/request-arrived (System/nanoTime)))]
+     (if (nil? interrupted?)
+       req'
+       (assoc req' :aleph/interrupted? interrupted?)))))
 
 (defn netty-response->ring-response [rsp complete body]
   (->NettyResponse rsp complete body))

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -245,15 +245,17 @@
   :aleph/complete complete
   :body body)
 
-(defn netty-request->ring-request [^HttpRequest req ssl? ch body]
-  (assoc
-    (->NettyRequest
-      req
-      ssl?
-      ch
-      (AtomicBoolean. false)
-      (-> req .uri (.indexOf (int 63))) body)
-    :aleph/request-arrived (System/nanoTime)))
+(defn netty-request->ring-request [^HttpRequest req ssl? ch body interrupted?]
+  (let [req' (-> (->NettyRequest
+                  req
+                  ssl?
+                  ch
+                  (AtomicBoolean. false)
+                  (-> req .uri (.indexOf (int 63))) body)
+                 (assoc :aleph/request-arrived (System/nanoTime)))]
+    (if (nil? interrupted?)
+      req'
+      (assoc req' :aleph/interrupted? interrupted?))))
 
 (defn netty-response->ring-response [rsp complete body]
   (->NettyResponse rsp complete body))

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -288,12 +288,12 @@
 (def default-error-response
   {:status 500
    :headers {"content-type" "text/plain"}
-   :body "Internal server error"})
+   :body "Internal Server Error"})
 
 (def default-unavailable-response
   {:status 503
    :headers {"content-type" "text/plain"}
-   :body "503 Service Unavailable"})
+   :body "Service Unavailable"})
 
 ;; Logs exception and returns default 500 response
 ;; not to expose internal logic to the client

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -623,14 +623,14 @@
                  :else
                  (send-streaming-body message-sent? ch msg body))
                (catch Throwable e
-                ;; technically, HTTP message might still not be sent
-                ;; what we mean in reallity is "out code didn't crash
-                ;; before asking Netty to send message". if something
-                ;; happens on I/O loop, we will get exception as a
-                ;; ChannelFuture failure rather than synchronosly with
-                ;; this block
+                 ;; technically, HTTP message might still not be sent
+                 ;; what we mean in reallity is "out code didn't crash
+                 ;; before asking Netty to send message". if something
+                 ;; happens on I/O loop, we will get exception as a
+                 ;; ChannelFuture failure rather than synchronosly with
+                 ;; this block
                  (when (and (instance? HttpResponse msg)
-                            (true? (.get message-sent?)))
+                            (false? (.get message-sent?)))
                    (send-internal-error message-sent? ch msg))
                  (handle-exception error-logger body e keep-alive? ch)))]
 

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -196,7 +196,7 @@
                       :else
                       (invalid-value-response req rsp))))))))))))
 
-(defn exception-handler [ctx ex]
+(defn handle-exception [ctx ex]
   (cond
     ;; do not need to log an entire stack trace when SSL handshake failed
     (http/ssl-handshake-error? ex)
@@ -335,7 +335,7 @@
 
       :exception-caught
       ([_ ctx ex]
-        (exception-handler ctx ex))
+        (handle-exception ctx ex))
 
       :channel-inactive
       ([_ ctx]
@@ -385,7 +385,7 @@
 
       :exception-caught
       ([_ ctx ex]
-        (exception-handler ctx ex))
+        (handle-exception ctx ex))
 
       :channel-inactive
       ([_ ctx]

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -30,7 +30,6 @@
      ChannelHandlerContext
      ChannelHandler
      ChannelPipeline]
-    [io.netty.channel.embedded EmbeddedChannel]
     [io.netty.handler.stream ChunkedWriteHandler]
     [io.netty.handler.timeout
      IdleState
@@ -52,7 +51,6 @@
      TextWebSocketFrame
      BinaryWebSocketFrame
      CloseWebSocketFrame
-     WebSocketFrame
      WebSocketFrameAggregator]
     [io.netty.handler.codec.http.websocketx.extensions.compression
      WebSocketServerCompressionHandler]
@@ -61,8 +59,6 @@
      IOException]
     [java.nio.channels
      ClosedChannelException]
-    [java.net
-     InetSocketAddress]
     [io.netty.util.concurrent
      FastThreadLocal]
     [java.util.concurrent

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -129,7 +129,7 @@
 
           (.set headers ^CharSequence http/connection-name (if keep-alive? keep-alive-value close-value))
 
-          (http/send-message ctx keep-alive? ssl? rsp body))))))
+          (http/send-message ctx keep-alive? ssl? rsp body error-logger))))))
 
 ;;;
 

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -383,7 +383,8 @@
               req
               @previous-response
               body
-              (HttpUtil/isKeepAlive req))))]
+              (HttpUtil/isKeepAlive req)
+              error-logger)))]
     (netty/channel-inbound-handler
 
       :exception-caught

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -255,6 +255,11 @@
     (-> ^Channel x .alloc .ioBuffer)
     (-> ^ChannelHandlerContext x .alloc .ioBuffer)))
 
+(defn channel-promise [x]
+  (if (instance? Channel x)
+    (.newPromise ^Channel x)
+    (.newPromise ^ChannelHandlerContext x)))
+
 (defn write [x msg]
   (if (instance? Channel x)
     (.write ^Channel x msg (.voidPromise ^Channel x))

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -129,6 +129,8 @@
 
 (def ^:const array-class (class (clojure.core/byte-array 0)))
 
+(def empty-buffer Unpooled/EMPTY_BUFFER)
+
 (defn buf->array [^ByteBuf buf]
   (let [dst (ByteBuffer/allocate (.readableBytes buf))]
     (doary [^ByteBuffer buf (.nioBuffers buf)]
@@ -185,7 +187,7 @@
     ([x]
      (cond
        (nil? x)
-       Unpooled/EMPTY_BUFFER
+       empty-buffer
 
        (instance? array-class x)
        (Unpooled/copiedBuffer ^bytes x)
@@ -205,7 +207,7 @@
      ;; todo(kachayev): do we really need to reallocate in case
      ;;                 we already have an instance of ByteBuf here?
      (if (nil? x)
-       Unpooled/EMPTY_BUFFER
+       empty-buffer
        (doto (allocate ch)
          (append-to-buf! x))))))
 

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -36,7 +36,6 @@
      KQueueSocketChannel
      KQueueServerSocketChannel]
     [io.netty.util Attribute AttributeKey]
-    [io.netty.handler.codec Headers]
     [io.netty.channel.nio NioEventLoopGroup]
     [io.netty.channel.socket ServerSocketChannel]
     [io.netty.channel.socket.nio

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -8,6 +8,8 @@
   (:import
     [java.io
      IOException]
+    [java.nio.channels
+     ClosedChannelException]
     [java.net
      InetSocketAddress]
     [io.netty.channel
@@ -27,14 +29,22 @@
 (alter-meta! #'->TcpConnection assoc :private true)
 
 (defn- ^ChannelHandler server-channel-handler
-  [handler {:keys [raw-stream?] :as options}]
+  [handler {:keys [raw-stream? error-logger] :as options}]
   (let [in (atom nil)]
     (netty/channel-inbound-handler
 
       :exception-caught
       ([_ ctx ex]
-        (when-not (instance? IOException ex)
-          (log/warn ex "error in TCP server")))
+        (let [error-logger' (or error-logger
+                                (fn [^Throwable ex]
+                                  (when-not (instance? IOException ex)
+                                    (log/warn ex "error in TCP server"))))]
+          (try
+            (error-logger ex)
+            (catch Throwable e
+              (log/warn e "error in error logger")))
+          (when-not (instance? ClosedChannelException)
+            (netty/close ctx))))
 
       :channel-inactive
       ([_ ctx]
@@ -74,7 +84,8 @@
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it.
    | `pipeline-transform` | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `raw-stream?` | if true, messages from the stream will be `io.netty.buffer.ByteBuf` objects rather than byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
-   | `num-event-loop-threads` | optional, defaults to double number of available processors."
+   | `num-event-loop-threads` | optional, defaults to double number of available processors.
+   | `error-logger` | optional, function to be invoked on each exception propagated through the pipeline up to the `handler`. Supposed to be used only for logging, crash reporting, metrics, etc rather than error recovery."
   [handler
    {:keys [port
            socket-address
@@ -84,7 +95,8 @@
            epoll?
            kqueue?
            log-activity
-           num-event-loop-threads]
+           num-event-loop-threads
+           error-logger]
     :or {bootstrap-transform identity
          pipeline-transform identity
          epoll? false

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -10,14 +10,10 @@
      IOException]
     [java.nio.channels
      ClosedChannelException]
-    [java.net
-     InetSocketAddress]
     [io.netty.channel
      Channel
      ChannelHandler
      ChannelPipeline]
-    [io.netty.handler.ssl
-     SslHandler]
     [io.netty.handler.logging LoggingHandler]))
 
 (p/def-derived-map TcpConnection [^Channel ch]

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -501,6 +501,56 @@
           count)))))
 
 ;;;
+;;; errors processing
+;;;
+
+(defn echo-string-handler [{:keys [body]}]
+  {:status 200
+   :body (bs/to-string body)})
+
+(deftest test-client-errors-handling
+  (testing "writing invalid request message"
+    (with-handler echo-string-handler
+      (is (thrown? IllegalArgumentException
+                   (-> (http/post (str "http://localhost:" port) {:body 42})
+                       (d/timeout! 1e3)
+                       deref)))))
+
+  (testing "writing invalid request body")
+  
+  (testing "reading invalid response message")
+  
+  (testing "reading invalid response body")
+  
+  (testing "connection closed while writing request message")
+  
+  (testing "connection closed while writing request body")
+  
+  (testing "connection closed while reading response message")
+  
+  (testing "connection closed while reading response body"))
+
+
+(deftest test-server-errors-handling
+  (testing "reject response when accepting connection")
+  
+  (testing "reading invalid request message")
+  
+  (testing "reading invalid request body")
+  
+  (testing "writing invalid response message")
+  
+  (testing "writing invalid response body")
+  
+  (testing "connection closed while reading request message")
+  
+  (testing "connection closed while reading request body")
+  
+  (testing "connection closed while writing response message")
+  
+  (testing "connection closed while writing response body"))
+
+;;;
 
 (deftest ^:benchmark benchmark-http
   (println "starting HTTP benchmark server on 8080")

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -709,7 +709,7 @@
                      (d/timeout! 1e3)
                      deref)]
         (is (= 500 (:status resp)))
-        (is (= "Internal server error" (bs/to-string (:body resp)))))))
+        (is (= "Internal Server Error" (bs/to-string (:body resp)))))))
 
   (testing "throwing exception within ring handler"
     (with-handler (fn [_] (throw (RuntimeException. "you shall not pass!")))
@@ -717,7 +717,7 @@
                      (d/timeout! 1e3)
                      deref)]
         (is (= 500 (:status resp)))
-        (is (= "Internal server error" (bs/to-string (:body resp)))))))
+        (is (= "Internal Server Error" (bs/to-string (:body resp)))))))
 
   (testing "reading invalid request message: bad request"
     ;; this request should fail with `IllegalArgumentException` "multiple Content-Lenght headers"

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -516,7 +516,13 @@
                        (d/timeout! 1e3)
                        deref)))))
 
-  (testing "writing invalid request body")
+  (testing "writing invalid request body"
+    (with-handler echo-string-handler
+      (is (thrown? IllegalArgumentException
+                   (-> (http/post (str "http://localhost:" port)
+                                  {:body (s/->source [1])})
+                       (d/timeout! 1e3)
+                       deref)))))
   
   (testing "reading invalid response message")
   

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -33,6 +33,7 @@
     [io.netty.handler.codec
      TooLongFrameException]
     [io.netty.channel
+     ChannelHandler
      ChannelHandlerContext
      ChannelPipeline]))
 

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -593,7 +593,11 @@
 
 (deftest test-server-errors-handling
   (testing "reject handler when accepting connection")
-  
+
+  (testing "throwing exception within reject handler")
+
+  (testing "throwing exception within ring handler")
+
   (testing "reading invalid request message")
   
   (testing "reading invalid request body")

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -521,7 +521,9 @@
   (testing "reading invalid response message")
   
   (testing "reading invalid response body")
-  
+
+  (testing "response body larger then content-length")
+
   (testing "connection closed while writing request message")
   
   (testing "connection closed while writing request body")
@@ -530,15 +532,24 @@
   
   (testing "connection closed while reading response body"))
 
-
 (deftest test-server-errors-handling
-  (testing "reject response when accepting connection")
+  (testing "reject handler when accepting connection")
   
   (testing "reading invalid request message")
   
   (testing "reading invalid request body")
   
-  (testing "writing invalid response message")
+  (testing "writing invalid response message"
+    (let [invalid-status-handler
+          (fn [{:keys [body]}]
+            (when (some? body) (bs/to-string body))
+            {:status 1045
+             :body "there's no such status"})]
+      (with-handler invalid-status-handler
+        (= 500 (-> (http/get (str "http://localhost:" port))
+                   (d/timeout! 1e3)
+                   deref
+                   :status)))))
   
   (testing "writing invalid response body")
   

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -775,10 +775,11 @@
             {:status 200
              :body (s/->source [1])})]
       (with-handler invalid-body-handler
-        (is (= 500 (-> (http-get (str "http://localhost:" port))
+        (let [resp (-> (http-get (str "http://localhost:" port))
                        (d/timeout! 1e3)
-                       deref
-                       :status)))))))
+                       deref)]
+          (is (= 200 (:status resp)))
+          (is (true? @(:aleph/interrupted? resp))))))))
 
 (deftest test-custom-error-handler
   (let [error (atom "")

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -759,6 +759,8 @@
           (fn [{:keys [body]}]
             (when (some? body) (bs/to-string body))
             {:status 1045
+             ;; this leads to `NullPointerException` in `http.core/normalize-header-key`
+             :headers {nil "not such header"}
              :body "there's no such status"})]
       (with-handler invalid-status-handler
         (is (= 500 (-> (http-get (str "http://localhost:" port))


### PR DESCRIPTION
There are quite a few changes introduced here. Would be more than happy to get comments before merging into `1.0.0` branch 😀 

Notably:
* both servers and clients close connection (context, to be more precise) in case of exceptions
* `error-logger` parameter is added for HTTP client/server, Websocket client/server to customize exceptions logging for those exceptions that could not be visible to user's code in any other way (e.g. something that happens within HTTP server pipeline)
* `TimeoutException` handlers are fixed in HTTP client (to avoid double disposal of the connections)
* HTTP decoder errors are now properly handled to deal with bad traffic, error code statuses are fixed
* HTTP client propagates throwable to the caller whenever possible (rather than just relying on connection being closed later)
* `:aleph/interrupted?` flag is introduce as a part of ring request object for HTTP server, making it's possible to track if streaming body was closed because of an error (e.g. decoder exception, premature close, etc)
* a lot of unit tests to check failure scenarios 