### PR TITLE
[dns] Extract dns-resolver-group builder code into a separate function

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -896,35 +896,33 @@ initialize an DnsAddressResolverGroup instance.
   (let [^Class
         channel-type (if (and epoll? (epoll-available?))
                        EpollDatagramChannel
-                       NioDatagramChannel)
+                       NioDatagramChannel)]
+    (cond-> (doto (DnsNameResolverBuilder.)
+              (.channelType channel-type)
+              (.maxPayloadSize max-payload-size)
+              (.maxQueriesPerResolve max-queries-per-resolve)
+              (.queryTimeoutMillis query-timeout)
+              (.ttl min-ttl max-ttl)
+              (.traceEnabled trace-enabled?)
+              (.optResourceEnabled opt-resources-enabled?)
+              (.ndots ndots)
+              (.decodeIdn decode-idn?)
+              (.recursionDesired recursion-desired?))
 
-        b (cond-> (doto (DnsNameResolverBuilder.)
-                    (.channelType channel-type)
-                    (.maxPayloadSize max-payload-size)
-                    (.maxQueriesPerResolve max-queries-per-resolve)
-                    (.queryTimeoutMillis query-timeout)
-                    (.ttl min-ttl max-ttl)
-                    (.traceEnabled trace-enabled?)
-                    (.optResourceEnabled opt-resources-enabled?)
-                    (.ndots ndots)
-                    (.decodeIdn decode-idn?)
-                    (.recursionDesired recursion-desired?))
+      (some? address-types)
+      (.resolvedAddressTypes (convert-address-types address-types))
 
-            (some? address-types)
-            (.resolvedAddressTypes (convert-address-types address-types))
+      (some? negative-ttl)
+      (.negativeTtl negative-ttl)
 
-            (some? negative-ttl)
-            (.negativeTtl negative-ttl)
+      (and (some? search-domains)
+           (not (empty? search-domains)))
+      (.searchDomains search-domains)
 
-            (and (some? search-domains)
-              (not (empty? search-domains)))
-            (.searchDomains search-domains)
-
-            (and (some? name-servers)
-              (not (empty? name-servers)))
-            (.nameServerProvider ^DnsServerAddressStreamProvider
-              (dns-name-servers-provider name-servers)))]
-    b))
+      (and (some? name-servers)
+           (not (empty? name-servers)))
+      (.nameServerProvider ^DnsServerAddressStreamProvider
+                           (dns-name-servers-provider name-servers)))))
 
 (defn dns-resolver-group
   "Creates an instance of DnsAddressResolverGroup that might be set as a resolver to

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -845,8 +845,9 @@
       (SingletonDnsServerAddressStreamProvider. (first addresses))
       (SequentialDnsServerAddressStreamProvider. ^Iterable addresses))))
 
-(defn dns-resolver-group
-  "Creates an instance of DnsAddressResolverGroup that might be set as a resolver to Bootstrap.
+(defn dns-resolver-group-builder
+  "Creates an instance of DnsAddressResolverGroupBuilder that is used to configure and 
+initialize an DnsAddressResolverGroup instance.
 
    DNS options are a map of:
 
@@ -923,7 +924,13 @@
               (not (empty? name-servers)))
             (.nameServerProvider ^DnsServerAddressStreamProvider
               (dns-name-servers-provider name-servers)))]
-    (DnsAddressResolverGroup. b)))
+    b))
+
+(defn dns-resolver-group
+  "Creates an instance of DnsAddressResolverGroup that might be set as a resolver to
+ Bootstrap. The supported options are the same as to `dns-resolver-group-builder`."
+  [dns-options]
+  (DnsAddressResolverGroup. (dns-resolver-group-builder dns-options)))
 
 (defn create-client
   ([pipeline-builder


### PR DESCRIPTION
Motivation: in certain cases, I want to use RoundRobinDnsAddressResolverGroup for DNS resolution. Some services provide a way of load balancing in the form of multiple DNS entries per URL, e.g. that's how AWS Load Balancer "balances" its own instances. The default DnsAddressResolverGroup caches just the first entry of the DNS server response and uses it throughout the cache invalidation period, leaving other returned entries unused. RR resolver caches the entire set of returned entries and goes over them on each request to the resolver.

In the first cut, I implemented the customizability via reflection which may seem clunky. The only other option I have is to pass a "constructor function" that accepts the Builder object and returns the resolver group. Please, tell me if that method would be preferred.

CC @kachayev.