### PR TITLE
Moving to newer netty 4.1.64.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.51.Final")
+(def netty-version "4.1.64.Final")
 
 (def netty-modules
   '[transport
@@ -16,7 +16,7 @@
     [byte-streams "0.2.5-alpha2"]
     [potemkin "0.4.5"]])
 
-(defproject aleph "0.4.7-alpha7"
+(defproject aleph "0.4.7-alpha8"
   :description "a framework for asynchronous communication"
   :repositories {"jboss" "https://repository.jboss.org/nexus/content/groups/public/"
                  "sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}


### PR DESCRIPTION
Upgrading netty to bring fix for https://nvd.nist.gov/vuln/detail/CVE-2021-21290