### PR TITLE
delay starting executors for graal compilation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 (def other-dependencies
   '[[org.clojure/tools.logging "1.1.0" :exclusions [org.clojure/clojure]]
     [manifold "0.1.9"]
-    [org.clj-commons/byte-streams "0.2.8"]
+    [org.clj-commons/byte-streams "0.2.9"]
     [potemkin "0.4.5"]])
 
 (defproject aleph "0.4.7-alpha9"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.64.Final")
+(def netty-version "4.1.69.Final")
 
 (def netty-modules
   '[transport

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -358,7 +358,7 @@
     (with-handler hello-handler
       @(d/future-with ex
          (let [rsp (http/get (str "http://localhost:" port) {:connection-pool pool})]
-           (is (= http/default-response-executor (.executor rsp))))))))
+           (is (= @http/default-response-executor (.executor rsp))))))))
 
 (defn echo-handler [req]
   {:status 200


### PR DESCRIPTION
Graal does not like it when `Thread` objects are initialized at build time (statically)
e.g. error:
```
Error: Detected a started Thread in the image heap. Threads running in the image generator are no longer running at image runtime.  To see how this object got instantiated use --trace-object-instantiation=java.lang.Thread. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
Trace: Object was reached by
        reading field java.util.concurrent.SynchronousQueue$TransferStack$SNode.waiter of
                constant java.util.concurrent.SynchronousQueue$TransferStack$SNode@20bf1f43 reached by
        reading field java.util.concurrent.SynchronousQueue$TransferStack.head of
                constant java.util.concurrent.SynchronousQueue$TransferStack@36676ee4 reached by
        reading field java.util.concurrent.SynchronousQueue.transferer of
                constant java.util.concurrent.SynchronousQueue@74f498f2 reached by
        reading field io.aleph.dirigiste.Executor._queue of
                constant io.aleph.dirigiste.Executor@2aa705b1 reached by
        reading field clojure.lang.Var.root of
                constant clojure.lang.Var@1375a85a reached by
        indexing into array
                constant java.lang.Object[]@6084b3c0 reached by
        reading field clojure.lang.PersistentHashMap$BitmapIndexedNode.array of
                constant clojure.lang.PersistentHashMap$BitmapIndexedNode@6423ded3 reached by
        indexing into array
                constant clojure.lang.PersistentHashMap$INode[]@60c39780 reached by
        reading field clojure.lang.PersistentHashMap$ArrayNode.array of
                constant clojure.lang.PersistentHashMap$ArrayNode@2f013229 reached by
        reading field clojure.lang.PersistentHashMap.root of
                constant clojure.lang.PersistentHashMap@60600939 reached by
        reading field java.util.concurrent.atomic.AtomicReference.value of
                constant java.util.concurrent.atomic.AtomicReference@72e17dd8 reached by
        reading field clojure.lang.Namespace.mappings of
                constant clojure.lang.Namespace@56703b62 reached by
        indexing into array
                constant java.lang.Object[]@757237be reached by
        reading field clojure.lang.PersistentHashMap$BitmapIndexedNode.array of
                constant clojure.lang.PersistentHashMap$BitmapIndexedNode@6536badd reached by
        reading field clojure.lang.PersistentHashMap.root of
                constant clojure.lang.PersistentHashMap@7fe0398d reached by
        reading field java.util.concurrent.atomic.AtomicReference.value of
                constant java.util.concurrent.atomic.AtomicReference@c5658fe reached by
        reading field clojure.lang.Namespace.aliases of
                constant clojure.lang.Namespace@1d526bdd reached by
        reading field clojure.lang.Var.ns of
                constant clojure.lang.Var@53f5d68d reached by
        scanning method via.adapters.aleph$websocket_adapter$reify__15706.disconnect(aleph.clj:32)
Call path from entry point to via.adapters.aleph$websocket_adapter$reify__15706.disconnect(Object):
        at via.adapters.aleph$websocket_adapter$reify__15706.disconnect(aleph.clj:32)
        at via.adapter$fn__667$G__609__670.invoke(adapter.cljc:15)
        at clojure.core.proxy$clojure.lang.APersistentMap$ff19274a.applyTo(Unknown Source)
        at graal_test.main.main(Unknown Source)
        at com.oracle.svm.core.JavaMainWrapper.runCore(JavaMainWrapper.java:146)
        at com.oracle.svm.core.JavaMainWrapper.run(JavaMainWrapper.java:182)
        at com.oracle.svm.core.code.IsolateEnterStub.JavaMainWrapper_run_5087f5482cc9a6abc971913ece43acb471d2631b(generated:0)
```
Wrapping the statically defined `connection-pool`s and `executor`s with `delay` ensures that the threads are not started until runtime.

Also upgrading `netty` resolves this object initialization error when compiling with graal:
```
Fatal error:com.oracle.svm.core.util.VMError$HostedError: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  To see how this object got instantiated use --trace-object-instantiation=java.util.Random. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
```

And finally when https://github.com/clj-commons/byte-streams/pull/50 gets merged I would like to include up-versioning `byte-streams` in this pr.