### PR TITLE
Update netty to 4.1.74.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.65.Final")
+(def netty-version "4.1.74.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
This pulls in fixes for [CVE-2021-37136](https://nvd.nist.gov/vuln/detail/CVE-2021-37136), [CVE-2021-37137](https://nvd.nist.gov/vuln/detail/CVE-2021-37137) and [CVE-2021-43797](https://nvd.nist.gov/vuln/detail/CVE-2021-43797).

While the first two don't appear to be relevant to aleph out of the box (i.e. a user would have to manually instantiate these decoders), the last one might affect aleph HTTP server users directly.