### PR TITLE
Remove test dependency on /usr/share/dict/words

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
 
     steps:
       - checkout
-      - run: sudo apt-get install wbritish
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -234,7 +234,9 @@
             @(http-get (str "https://localhost:" port "/" path)))))
        (str path "path failed")))))
 
-(def words (slurp "/usr/share/dict/words"))
+(def characters
+  (let [charset (conj (mapv char (range 32 127)) \newline)]
+    (repeatedly #(rand-nth charset))))
 
 (deftest test-bulk-requests
   (with-handler basic-handler
@@ -255,13 +257,13 @@
 (deftest test-echo
   (with-handler basic-handler
     (doseq [len [1e3 1e4 1e5 1e6 1e7]]
-      (let [words (->> words (take len) (apply str))
+      (let [characters (->> characters (take len) (apply str))
             body (:body
                    @(http-put (str "http://localhost:" port "/echo")
-                      {:body words}))
+                      {:body characters}))
             body' (bs/to-string body)]
-        (assert (== (min (count words) len) (count body')))
-        (is (= words body'))))))
+        (assert (== (min (count characters) len) (count body')))
+        (is (= characters body'))))))
 
 (deftest test-redirect
   (with-both-handlers basic-handler
@@ -293,11 +295,11 @@
 (deftest test-line-echo
   (with-handler basic-handler
     (doseq [len [1e3 1e4 1e5]]
-      (let [words (->> words (take len) (apply str))
+      (let [characters (->> characters (take len) (apply str))
             body (:body
                    @(http-put (str "http://localhost:" port "/line_echo")
-                      {:body words}))]
-        (is (= (.replace ^String words "\n" "") (bs/to-string body)))))))
+                      {:body characters}))]
+        (is (= (.replace ^String characters "\n" "") (bs/to-string body)))))))
 
 (deftest test-illegal-character-in-url
   (with-handler hello-handler

--- a/test/aleph/tcp_test.clj
+++ b/test/aleph/tcp_test.clj
@@ -19,8 +19,6 @@
        (finally
          (.close ^java.io.Closeable server#)))))
 
-(def words (slurp "/usr/share/dict/words"))
-
 (deftest test-echo
   (with-server (tcp/start-server echo-handler {:port 10001})
     (let [c @(tcp/client {:host "localhost", :port 10001})]

--- a/test/aleph/udp_test.clj
+++ b/test/aleph/udp_test.clj
@@ -16,8 +16,6 @@
        (finally
          (.close ^java.io.Closeable server#)))))
 
-(def words (slurp "/usr/share/dict/words"))
-
 (deftest test-echo
   (let [s @(udp/socket {:port 10001, :epoll? true})]
     (s/put! s {:host "localhost", :port 10001, :message "foo"})


### PR DESCRIPTION
This file is not present by default on many systems and in fact, on
systems like NixOS, it's not trivial to install at that path. Also,
there is an unchecked reliance on that file to be at least 1e7 bytes
long. If it is in fact shorter, the tests relying on it will just
silently run with shorter inputs.

Instead, just randomly generate printable ASCII characters. This seems
to be of comparable performance and doesn't have the above problems.