### PR TITLE
Update Netty to 4.1.65.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.64.Final")
+(def netty-version "4.1.65.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
4.1.64.Final had some regressions.

https://netty.io/news/2021/05/19/4-1-65-Final.html

> As netty 4.1.64.Final did include two regressions which were found quickly after the release we decided to not announce it all and just roll a 4.1.65.Final which includes everything.

Not sure if we want to do this before the release or not, but thought I'd open it for an upgrade shortly afterwards if not in this release.