### PR TITLE
Provide clj-kondo hook for def-http-method

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../resources/clj-kondo.exports/clj-commons/aleph"]}

--- a/resources/clj-kondo.exports/clj-commons/aleph/aleph/clj_kondo_hooks.clj
+++ b/resources/clj-kondo.exports/clj-commons/aleph/aleph/clj_kondo_hooks.clj
@@ -1,0 +1,6 @@
+(ns aleph.clj-kondo-hooks)
+
+(defmacro def-http-method [method]
+  `(defn ~method
+     ([url#])
+     ([url# options#])))

--- a/resources/clj-kondo.exports/clj-commons/aleph/config.edn
+++ b/resources/clj-kondo.exports/clj-commons/aleph/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:macroexpand {aleph.http/def-http-method aleph.clj-kondo-hooks/def-http-method}}}


### PR DESCRIPTION
This allows clj-kondo to properly lint aleph.http/post and friends. Similar case as https://github.com/ptaoussanis/encore/pull/56, for example (see there for some more explanation).