### PR TITLE
Add server option for user defined header key normalization function

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -51,7 +51,9 @@
    | `compression-level` | optional compression level, `1` yields the fastest compression and `9` yields the best compression, defaults to `6`. When set, enables http content compression regardless of the `compression?` flag value
    | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds
    | `continue-handler` | optional handler which is invoked when header sends \"Except: 100-continue\" header to test whether the request should be accepted or rejected. Handler should return `true`, `false`, ring responseo to be used as a reject response or deferred that yields one of those.
-   | `continue-executor` | optional `java.util.concurrent.Executor` which is used to handle requests passed to :continue-handler.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread."
+   | `continue-executor` | optional `java.util.concurrent.Executor` which is used to handle requests passed to :continue-handler.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread.
+   | `header-key-transform` | optional function that takes a String representation of a header key and returns a
+   normalized version used in the server response."
   [handler options]
   (server/start-server handler options))
 

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -116,14 +116,14 @@
       [server-value keep-alive-value close-value]
       (map #(HttpHeaders/newEntity %) ["Aleph/0.4.7" "Keep-Alive" "Close"])]
   (defn send-response
-    [^ChannelHandlerContext ctx keep-alive? ssl? rsp]
+    [^ChannelHandlerContext ctx keep-alive? ssl? rsp header-key-transform]
     (let [[^HttpResponse rsp body]
           (try
-            [(http/ring-response->netty-response rsp)
+            [(http/ring-response->netty-response rsp header-key-transform)
              (get rsp :body)]
             (catch Throwable e
               (let [rsp (error-response e)]
-                [(http/ring-response->netty-response rsp)
+                [(http/ring-response->netty-response rsp header-key-transform)
                  (get rsp :body)])))]
 
       (netty/safe-execute ctx
@@ -159,7 +159,8 @@
    ^HttpRequest req
    previous-response
    body
-   keep-alive?]
+   keep-alive?
+   header-key-transform]
   (let [^NettyRequest req' (http/netty-request->ring-request req ssl? (.channel ctx) body)
         head? (identical? HttpMethod/HEAD (.method req))
         rsp (if executor
@@ -206,7 +207,8 @@
                       {:status 204}
 
                       :else
-                      (invalid-value-response req rsp))))))))))))
+                      (invalid-value-response req rsp))
+                                 header-key-transform))))))))))
 
 (defn exception-handler [ctx ex]
   (when-not (instance? IOException ex)
@@ -226,7 +228,7 @@
     (fn [_] (netty/close ctx))))
 
 (defn ring-handler
-  [ssl? handler rejected-handler executor buffer-capacity]
+  [ssl? handler rejected-handler executor buffer-capacity header-key-transform]
   (let [buffer-capacity (long buffer-capacity)
         request (atom nil)
         buffer (atom [])
@@ -246,7 +248,8 @@
               req
               @previous-response
               (when body (bs/to-input-stream body))
-              (HttpHeaders/isKeepAlive req))))
+              (HttpHeaders/isKeepAlive req)
+              header-key-transform)))
 
         process-request
         (fn [ctx req]
@@ -348,7 +351,7 @@
           (.fireChannelRead ctx msg))))))
 
 (defn raw-ring-handler
-  [ssl? handler rejected-handler executor buffer-capacity]
+  [ssl? handler rejected-handler executor buffer-capacity header-key-transform]
   (let [buffer-capacity (long buffer-capacity)
         stream (atom nil)
         previous-response (atom nil)
@@ -365,7 +368,8 @@
               req
               @previous-response
               body
-              (HttpUtil/isKeepAlive req))))]
+              (HttpUtil/isKeepAlive req)
+              header-key-transform)))]
     (netty/channel-inbound-handler
 
       :exception-caught
@@ -469,7 +473,8 @@
      compression-level
      idle-timeout
      continue-handler
-     continue-executor]
+     continue-executor
+     header-key-transform]
     :or
     {request-buffer-size 16384
      max-initial-line-length 8192
@@ -479,8 +484,8 @@
      idle-timeout 0}}]
   (fn [^ChannelPipeline pipeline]
     (let [handler (if raw-stream?
-                    (raw-ring-handler ssl? handler rejected-handler executor request-buffer-size)
-                    (ring-handler ssl? handler rejected-handler executor request-buffer-size))
+                    (raw-ring-handler ssl? handler rejected-handler executor request-buffer-size header-key-transform)
+                    (ring-handler ssl? handler rejected-handler executor request-buffer-size header-key-transform))
           ^ChannelHandler
           continue-handler (if (nil? continue-handler)
                              (HttpServerExpectContinueHandler.)
@@ -519,7 +524,8 @@
            epoll?
            compression?
            continue-handler
-           continue-executor]
+           continue-executor
+           header-key-transform]
     :or {bootstrap-transform identity
          pipeline-transform identity
          shutdown-executor? true
@@ -562,7 +568,8 @@
       (pipeline-builder
         handler
         pipeline-transform
-        (assoc options :executor executor :ssl? (or manual-ssl? (boolean ssl-context)) :continue-executor continue-executor'))
+        (assoc options :executor executor :ssl? (or manual-ssl? (boolean ssl-context)) :continue-executor continue-executor'
+                       :header-key-transform header-key-transform))
       ssl-context
       bootstrap-transform
       (when (and shutdown-executor? (or (instance? ExecutorService executor)

--- a/test/aleph/http/core_test.clj
+++ b/test/aleph/http/core_test.clj
@@ -5,7 +5,7 @@
     [aleph.http.core :as core])
   (:import
     [io.netty.handler.codec.http
-     DefaultHttpRequest]))
+     DefaultHttpRequest DefaultHttpResponse]))
 
 (deftest test-HeaderMap-keys
   (let [^DefaultHttpRequest req (core/ring-request->netty-request
@@ -16,3 +16,13 @@
         map (core/headers->map (.headers req))
         dissoc-map (dissoc map "authorization")]
     (is (= #{"accept"}  (-> dissoc-map keys set)))))
+
+(deftest test-map->headerkeys
+  (let [ring-response {:status 200
+                       :headers {"Content-Type" "text/html"
+                                 "etag" "c561c68d0ba92bbeb8b0f612a9199f722e3a621a"
+                                 "x-amz-meta-key" "foo"}}
+        ^DefaultHttpResponse resp (core/ring-response->netty-response ring-response)
+        ^DefaultHttpResponse resp-hkt (core/ring-response->netty-response ring-response identity)]
+    (is (= #{"ETag" "X-Amz-Meta-Key" "Content-Type"} (-> resp .headers keys set)))
+    (is (= #{"ETag" "x-amz-meta-key" "Content-Type"} (-> resp-hkt .headers keys set)))))


### PR DESCRIPTION
### Description

Since some of our response header keys are case sensitive we would like to handle these differently than the vanilla capitalization currently used. The suggested change adds a server option `:header-key-transform`  to pass in a function that is used for the non-standard header keys. This function expects a header key string and returns a normalized string. Looking forward to your feedback.   
