### PR TITLE
Add missing type hint on websocket-server-handler

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -683,7 +683,7 @@
                (netty/release msg)
                ;; reusing the same buffer
                ;; will be deallocated by Netty
-               (.close handshaker ch msg))
+               (.close handshaker ch ^CloseWebSocketFrame msg))
 
              :else
              ;; no need to release buffer when passing to a next handler


### PR DESCRIPTION
## Description

A type hint was missing causing reflection warning
on the `aleph.http.server/websocket-server-handler` function

## Impacts

None

## Testing done

Evaluating `aleph/http/server/clj` :

__Before__
```
Reflection warning, /home/arnaudgeiser/code/aleph/src/aleph/http/server.clj:686:16 - call to method close on io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker can't be resolved (argument types: io.netty.channel.Channel, java.lang.Object).
```

__After__

(Nothing)
```
```