### PR TITLE
client: Accept empty file

### DIFF
--- a/test/aleph/ssl.clj
+++ b/test/aleph/ssl.clj
@@ -1,0 +1,55 @@
+(ns aleph.ssl
+  (:require [aleph.netty :as netty])
+  (:import [io.netty.handler.ssl SslContextBuilder ClientAuth]
+           [java.io ByteArrayInputStream]
+           [java.security KeyFactory PrivateKey]
+           [java.security.cert CertificateFactory X509Certificate]
+           [java.security.spec RSAPrivateCrtKeySpec]
+           [org.apache.commons.codec.binary Base64]))
+
+(set! *warn-on-reflection* false)
+
+(defn gen-cert
+  ^X509Certificate [^String pemstr]
+  (.generateCertificate (CertificateFactory/getInstance "X.509")
+                        (ByteArrayInputStream. (Base64/decodeBase64 pemstr))))
+
+(defn gen-key
+  ^PrivateKey [public-exponent k]
+  (let [k (zipmap
+           (keys k)
+           (->> k
+                vals
+                (map #(BigInteger. ^String % 16))))
+        spec (RSAPrivateCrtKeySpec.
+              (:modulus k)
+              (biginteger public-exponent)
+              (:privateExponent k)
+              (:prime1 k)
+              (:prime2 k)
+              (:exponent1 k)
+              (:exponent2 k)
+              (:coefficient k))
+        gen (KeyFactory/getInstance "RSA")]
+    (.generatePrivate gen spec)))
+
+(def server-cert (gen-cert (read-string (slurp "test/server_cert.edn"))))
+(def server-key (gen-key 65537 (read-string (slurp "test/server_key.edn"))))
+
+(def ca-cert (gen-cert (read-string (slurp "test/ca_cert.edn"))))
+(def ca-key (gen-key 65537 (read-string (slurp "test/ca_key.edn"))))
+
+(def ^X509Certificate client-cert (gen-cert (read-string (slurp "test/client_cert.edn"))))
+(def client-key (gen-key 65537 (read-string (slurp "test/client_key.edn"))))
+
+(def server-ssl-context
+  (-> (SslContextBuilder/forServer server-key (into-array X509Certificate [server-cert]))
+      (.trustManager (into-array X509Certificate [ca-cert]))
+      (.clientAuth ClientAuth/OPTIONAL)
+      .build))
+
+(def client-ssl-context
+  (netty/ssl-client-context
+   {:private-key client-key
+    :certificate-chain (into-array X509Certificate [client-cert])
+    :trust-store (into-array X509Certificate [ca-cert])}))

--- a/test/aleph/tcp_ssl_test.clj
+++ b/test/aleph/tcp_ssl_test.clj
@@ -1,70 +1,16 @@
 (ns aleph.tcp-ssl-test
-  (:use
-    [clojure test])
   (:require [aleph.tcp-test :refer [with-server]]
-    [aleph.tcp :as tcp]
-    [aleph.netty :as netty]
-    [manifold.stream :as s]
-    [byte-streams :as bs])
-  (:import
-   [java.security KeyFactory PrivateKey]
-   [java.security.cert CertificateFactory X509Certificate]
-   [java.io ByteArrayInputStream]
-   [java.security.spec RSAPrivateCrtKeySpec]
-   [io.netty.handler.ssl SslContextBuilder ClientAuth]
-   [org.apache.commons.codec.binary Base64]))
+            [aleph.tcp :as tcp]
+            [aleph.ssl :as ssl]
+            [aleph.netty :as netty]
+            [byte-streams :as bs]
+            [clojure.test :refer [deftest is]]
+            [manifold.stream :as s])
+  (:import [java.security.cert X509Certificate]))
 
 (netty/leak-detector-level! :paranoid)
 
 (set! *warn-on-reflection* false)
-
-(defn gen-key
-  ^PrivateKey [public-exponent k]
-  (let [k (zipmap
-            (keys k)
-            (->> k
-              vals
-              (map #(BigInteger. % 16))))
-        spec (RSAPrivateCrtKeySpec.
-               (:modulus k)
-               (biginteger public-exponent)
-               (:privateExponent k)
-               (:prime1 k)
-               (:prime2 k)
-               (:exponent1 k)
-               (:exponent2 k)
-               (:coefficient k))
-        gen (KeyFactory/getInstance "RSA")]
-    (.generatePrivate gen spec)))
-
-(defn gen-cert
-  ^X509Certificate [^String pemstr]
-  (.generateCertificate (CertificateFactory/getInstance "X.509")
-    (ByteArrayInputStream. (Base64/decodeBase64 pemstr))))
-
-(def ca-cert (gen-cert (read-string (slurp "test/ca_cert.edn"))))
-
-(def ca-key (gen-key 65537 (read-string (slurp "test/ca_key.edn"))))
-
-(def server-cert (gen-cert (read-string (slurp "test/server_cert.edn"))))
-
-(def server-key (gen-key 65537 (read-string (slurp "test/server_key.edn"))))
-
-(def ^X509Certificate client-cert (gen-cert (read-string (slurp "test/client_cert.edn"))))
-
-(def client-key (gen-key 65537 (read-string (slurp "test/client_key.edn"))))
-
-(def server-ssl-context
-  (-> (SslContextBuilder/forServer server-key (into-array X509Certificate [server-cert]))
-    (.trustManager (into-array X509Certificate [ca-cert]))
-    (.clientAuth ClientAuth/OPTIONAL)
-    .build))
-
-(def client-ssl-context
-  (netty/ssl-client-context
-    {:private-key client-key
-     :certificate-chain (into-array X509Certificate [client-cert])
-     :trust-store (into-array X509Certificate [ca-cert])}))
 
 (defn ssl-echo-handler
   [s c]
@@ -73,7 +19,7 @@
     ; note we need to inspect the SSL session *after* we start reading
     ; data. Otherwise, the session might not be set up yet.
     (s/map (fn [msg]
-             (is (= (.getSubjectDN ^X509Certificate client-cert)
+             (is (= (.getSubjectDN ^X509Certificate ssl/client-cert)
                    (.getSubjectDN ^X509Certificate (first (.getPeerCertificates (:ssl-session c))))))
              msg)
       s)
@@ -82,9 +28,9 @@
 (deftest test-ssl-echo
   (with-server (tcp/start-server ssl-echo-handler
                                  {:port 10001
-                                  :ssl-context server-ssl-context})
+                                  :ssl-context ssl/server-ssl-context})
     (let [c @(tcp/client {:host "localhost"
                           :port 10001
-                          :ssl-context client-ssl-context})]
+                          :ssl-context ssl/client-ssl-context})]
       (s/put! c "foo")
       (is (= "foo" (bs/to-string @(s/take! c)))))))


### PR DESCRIPTION
## Description

In case of TLS usage (`ssl-context`) and an empty file, a `NullPointerException` was raised on the following code because `bs/to-byte-buffers` was returning `nil` and a `manifold.stream/->source` cannot be build from it.

```clojure
(send-streaming-body ch msg
      (-> file
        (bs/to-byte-buffers {:chunk-size (.-chunk-size file)})
        s/->source))
```

This issue has been reported here : https://github.com/clj-commons/aleph/issues/559