### PR TITLE
Update byte-streams and use clj-commons namespace prefixes

### DIFF
--- a/examples/src/aleph/examples/http.clj
+++ b/examples/src/aleph/examples/http.clj
@@ -7,7 +7,7 @@
     [compojure.route :as route]
     [compojure.response :refer [Renderable]]
     [aleph.http :as http]
-    [byte-streams :as bs]
+    [clj-commons.byte-streams :as bs]
     [manifold.stream :as s]
     [manifold.deferred :as d]
     [clojure.core.async :as a]

--- a/examples/src/aleph/examples/udp.clj
+++ b/examples/src/aleph/examples/udp.clj
@@ -1,10 +1,9 @@
 (ns aleph.examples.udp
   (:require
-    [manifold.deferred :as d]
     [manifold.stream :as s]
     [aleph.udp :as udp]
     [clojure.string :as str]
-    [byte-streams :as bs]))
+    [clj-commons.byte-streams :as bs]))
 
 ;; Full documentation for the `aleph.udp` namespace can be found [here](http://aleph.io/codox/aleph/aleph.udp.html).
 

--- a/examples/src/aleph/examples/websocket.clj
+++ b/examples/src/aleph/examples/websocket.clj
@@ -4,11 +4,9 @@
     [ring.middleware.params :as params]
     [compojure.route :as route]
     [aleph.http :as http]
-    [byte-streams :as bs]
     [manifold.stream :as s]
     [manifold.deferred :as d]
-    [manifold.bus :as bus]
-    [clojure.core.async :as a]))
+    [manifold.bus :as bus]))
 
 (def non-websocket-request
   {:status 400
@@ -111,8 +109,8 @@
 
 ;; Here we create two clients, and have them speak to each other
 (let [conn1 @(http/websocket-client "ws://localhost:10000/chat")
-      conn2 @(http/websocket-client "ws://localhost:10000/chat")
-      ]
+      conn2 @(http/websocket-client "ws://localhost:10000/chat")]
+      
 
   ;; sign our two users in
   (s/put-all! conn1 ["shoes and ships" "Alice"])
@@ -126,7 +124,7 @@
   (s/put! conn2 "hi!")
 
   @(s/take! conn1)   ;=> "Bob: hi!"
-  @(s/take! conn2)   ;=> "Bob: hi!"
-  )
+  @(s/take! conn2))   ;=> "Bob: hi!"
+  
 
 (.close s)

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 (def other-dependencies
   '[[org.clojure/tools.logging "1.1.0" :exclusions [org.clojure/clojure]]
     [manifold "0.1.9"]
-    [org.clj-commons/byte-streams "0.2.10"]
+    [org.clj-commons/byte-streams "0.3.0"]
     [potemkin "0.4.5"]])
 
 (defproject aleph "0.4.7"

--- a/project.clj
+++ b/project.clj
@@ -12,8 +12,9 @@
 
 (def other-dependencies
   '[[org.clojure/tools.logging "1.1.0" :exclusions [org.clojure/clojure]]
-    [manifold "0.1.9"]
+    [manifold "0.2.3"]
     [org.clj-commons/byte-streams "0.3.0"]
+    [org.clj-commons/primitive-math "1.0.0"]
     [potemkin "0.4.5"]])
 
 (defproject aleph "0.4.7"

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -1,7 +1,7 @@
 (ns aleph.http.client
   (:require
     [clojure.tools.logging :as log]
-    [byte-streams :as bs]
+    [clj-commons.byte-streams :as bs]
     [manifold.deferred :as d]
     [manifold.stream :as s]
     [aleph.http.core :as http]

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -8,7 +8,7 @@
     [manifold.deferred :as d]
     [manifold.stream :as s]
     [manifold.executor :as ex]
-    [byte-streams :as bs]
+    [clj-commons.byte-streams :as bs]
     [clojure.edn :as edn]
     ;; leave this dependency to make sure that HeaderMap is already compiled
     [aleph.http.core :as http])

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -6,8 +6,8 @@
     [clojure.tools.logging :as log]
     [clojure.set :as set]
     [clojure.string :as str]
-    [byte-streams :as bs]
-    [byte-streams.graph :as g]
+    [clj-commons.byte-streams :as bs]
+    [clj-commons.byte-streams.graph :as g]
     [potemkin :as p]
     [clojure.java.io :as io])
   (:import

--- a/src/aleph/http/encoding.clj
+++ b/src/aleph/http/encoding.clj
@@ -1,7 +1,7 @@
 (ns aleph.http.encoding
   (:require
-    [byte-streams :as bs]
-    [primitive-math :as p])
+    [clj-commons.byte-streams :as bs]
+    [clj-commons.primitive-math :as p])
   (:import
     [io.netty.buffer
      ByteBuf

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -1,7 +1,7 @@
 (ns aleph.http.multipart
   (:require
    [clojure.core :as cc]
-   [byte-streams :as bs]
+   [clj-commons.byte-streams :as bs]
    [aleph.http.encoding :refer [encode]]
    [aleph.http.core :as http-core]
    [aleph.netty :as netty]

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -3,7 +3,7 @@
     [aleph.http.core :as http]
     [aleph.netty :as netty]
     [aleph.flow :as flow]
-    [byte-streams :as bs]
+    [clj-commons.byte-streams :as bs]
     [clojure.tools.logging :as log]
     [clojure.string :as str]
     [manifold.deferred :as d]

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -1,13 +1,13 @@
 (ns aleph.netty
   (:refer-clojure :exclude [flush])
   (:require
-    [byte-streams :as bs]
+    [clj-commons.byte-streams :as bs]
     [clojure.tools.logging :as log]
     [manifold.deferred :as d]
     [manifold.executor :as e]
     [manifold.stream :as s]
     [manifold.stream.core :as manifold]
-    [primitive-math :as p]
+    [clj-commons.primitive-math :as p]
     [clojure
      [string :as str]
      [set :as set]]

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -3,7 +3,7 @@
     [aleph.http :as http]
     [aleph.http.core :as core]
     [aleph.http.multipart :as mp]
-    [byte-streams :as bs]
+    [clj-commons.byte-streams :as bs]
     [clojure.edn :as edn]
     [clojure.test :refer [deftest testing is]]
     [manifold.deferred :as d]

--- a/test/aleph/http_continue_test.clj
+++ b/test/aleph/http_continue_test.clj
@@ -5,7 +5,7 @@
              [netty :as netty]
              [flow :as flow]
              [tcp :as tcp]]
-            [byte-streams :as bs]
+            [clj-commons.byte-streams :as bs]
             [manifold.deferred :as d]
             [manifold.stream :as s]
             [clojure.string :as str])

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -10,7 +10,7 @@
      [ssl :as ssl]
      [tcp :as tcp]]
     [aleph.http.core :as core]
-    [byte-streams :as bs]
+    [clj-commons.byte-streams :as bs]
     [manifold.deferred :as d]
     [manifold.stream :as s])
   (:import

--- a/test/aleph/ring_test.clj
+++ b/test/aleph/ring_test.clj
@@ -2,7 +2,7 @@
   (:use
     [clojure test])
   (:require
-    [byte-streams :as bs]
+    [clj-commons.byte-streams :as bs]
     [aleph.netty :as netty]
     [aleph.http :as http])
   (:import

--- a/test/aleph/tcp_ssl_test.clj
+++ b/test/aleph/tcp_ssl_test.clj
@@ -3,7 +3,7 @@
             [aleph.tcp :as tcp]
             [aleph.ssl :as ssl]
             [aleph.netty :as netty]
-            [byte-streams :as bs]
+            [clj-commons.byte-streams :as bs]
             [clojure.test :refer [deftest is]]
             [manifold.stream :as s])
   (:import [java.security.cert X509Certificate]))

--- a/test/aleph/tcp_test.clj
+++ b/test/aleph/tcp_test.clj
@@ -4,7 +4,7 @@
   (:require
     [manifold.stream :as s]
     [aleph.netty :as netty]
-    [byte-streams :as bs]
+    [clj-commons.byte-streams :as bs]
     [aleph.tcp :as tcp]))
 
 (netty/leak-detector-level! :paranoid)

--- a/test/aleph/udp_test.clj
+++ b/test/aleph/udp_test.clj
@@ -4,7 +4,7 @@
   (:require
     [manifold.stream :as s]
     [aleph.netty :as netty]
-    [byte-streams :as bs]
+    [clj-commons.byte-streams :as bs]
     [aleph.udp :as udp]))
 
 (netty/leak-detector-level! :paranoid)

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -6,7 +6,7 @@
     [manifold.stream :as s]
     [manifold.time :as time]
     [aleph.netty :as netty]
-    [byte-streams :as bs]
+    [clj-commons.byte-streams :as bs]
     [aleph.http :as http]
     [aleph.http.core :as http-core]
     [aleph.http.server :as http-server]


### PR DESCRIPTION
Update byte-streams to 0.3.0 and use `clj-commons` prefix for `byte-streams` and `primitive-math`.