### PR TITLE
Use FastThreadLocalThread

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 
 (def other-dependencies
   '[[org.clojure/tools.logging "1.1.0" :exclusions [org.clojure/clojure]]
-    [manifold "0.2.3"]
+    [manifold "0.2.4"]
     [org.clj-commons/byte-streams "0.3.0"]
     [org.clj-commons/primitive-math "1.0.0"]
     [potemkin "0.4.5"]])

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -4,6 +4,7 @@
     [clj-commons.byte-streams :as bs]
     [clojure.tools.logging :as log]
     [manifold.deferred :as d]
+    [manifold.executor :as e]
     [manifold.stream :as s]
     [manifold.stream.core :as manifold]
     [clj-commons.primitive-math :as p]
@@ -51,7 +52,7 @@
      ResourceLeakDetector$Level]
     [java.net URI SocketAddress InetSocketAddress]
     [io.netty.util.concurrent
-     DefaultThreadFactory GenericFutureListener Future]
+     FastThreadLocalThread GenericFutureListener Future]
     [java.io InputStream File]
     [java.nio ByteBuffer]
     [io.netty.util.internal SystemPropertyUtil]
@@ -792,18 +793,27 @@
   (let [cpu-count (->> (Runtime/getRuntime) (.availableProcessors))]
     (max 1 (SystemPropertyUtil/getInt "io.netty.eventLoopThreads" (* cpu-count 2)))))
 
+(defn ^ThreadFactory enumerating-thread-factory [prefix daemon?]
+  (let [num-threads (atom 0)]
+    (e/thread-factory
+     #(str prefix "-" (swap! num-threads inc))
+     (deliver (promise) nil)
+     nil
+     daemon?
+     (fn [group target name stack-size] (FastThreadLocalThread. group target name stack-size)))))
+
 (def ^String client-event-thread-pool-name "aleph-netty-client-event-pool")
 
 (def epoll-client-group
   (delay
     (let [thread-count (get-default-event-loop-threads)
-          thread-factory (DefaultThreadFactory. client-event-thread-pool-name true)]
+          thread-factory (enumerating-thread-factory client-event-thread-pool-name true)]
       (EpollEventLoopGroup. (long thread-count) thread-factory))))
 
 (def nio-client-group
   (delay
     (let [thread-count (get-default-event-loop-threads)
-          thread-factory (DefaultThreadFactory. client-event-thread-pool-name true)]
+          thread-factory (enumerating-thread-factory client-event-thread-pool-name true)]
       (NioEventLoopGroup. (long thread-count) thread-factory))))
 
 (defn convert-address-types [address-types]
@@ -993,7 +1003,7 @@ initialize an DnsAddressResolverGroup instance.
    epoll?]
   (let [num-cores      (.availableProcessors (Runtime/getRuntime))
         num-threads    (* 2 num-cores)
-        thread-factory (DefaultThreadFactory. "aleph-netty-server-event-pool")
+        thread-factory (enumerating-thread-factory "aleph-netty-server-event-pool" false)
         closed?        (atom false)
 
         ^EventLoopGroup group


### PR DESCRIPTION
## Description

~This PR makes use of the `io.netty.util.concurrent.DefaultThreadFactory` from Netty instead of using the implementation of `manifold.executor`.
The reason for this is that `DefaultThreadFactory` is creating `FastThreadLocalThread` instead of JDK `Thread` [1].
As demonstrated on the following code, it's supposed to be faster (`fastGet`) [2].~

This PR ensures we are using `io.netty.util.concurrent.FastThreadLocalThread` when creating the Aleph executor.

Here are some (interesting?) links on  Netty:
- https://github.com/netty/netty/pull/11999
- https://github.com/netty/netty/issues/4401
- https://github.com/netty/netty/issues/4402


[1] : https://github.com/netty/netty/blob/f17b5fe3cd7155a0281d081edabe223e131ba332/common/src/main/java/io/netty/util/concurrent/DefaultThreadFactory.java#L121
[2] : https://github.com/netty/netty/blob/69e1d36cb19c034dcdcaaa1085c0387435c06975/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java#L100-L124

## Testing done

### Exercised code

```clojure
(require '[clj-async-profiler.core :as prof])

(deftest test-compressed-response
  (prof/profile (with-compressed-handler basic-handler
                  (doseq [[index [path result]] (map-indexed vector expected-results)
                          :let [resp @(http-get (str "http://localhost:" port "/" path)
                                                {:headers {:accept-encoding "gzip"}})
                                unzipped (try
                                           (bs/to-string (GZIPInputStream. (:body resp)))
                                           (catch ZipException _ nil))]]
                    (is (= "gzip" (get-in resp [:headers :content-encoding])) 'content-encoding-header-is-set)
                    (is (some? unzipped) 'should-be-valid-gzip)
                    (is (= result unzipped) 'decompressed-body-is-correct)))))


```

### Before
![02-cpu-flamegraph-2022-04-26-23-52-57](https://user-images.githubusercontent.com/5036764/165399525-b4e7e52b-91dc-4623-85cb-25bb7f41461c.svg)


### After
![01-cpu-flamegraph-2022-04-26-23-49-01](https://user-images.githubusercontent.com/5036764/165399444-066a1179-bf97-4e0d-9448-43caa48a16e1.svg)
