### PR TITLE
Attempt to provide correct API for multipart resources management

### DIFF
--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -19,6 +19,7 @@
     Charset]
    [java.net
     URLConnection]
+   [io.netty.util ReferenceCounted]
    [io.netty.util.internal
     ThreadLocalRandom]
    [io.netty.handler.codec.http
@@ -37,7 +38,9 @@
     InterfaceHttpData
     InterfaceHttpData$HttpDataType]))
 
-(defn boundary []
+(defn
+  ^{:deprecated "use aleph.http.multipart/encode-request instead"}
+  boundary []
   (-> (ThreadLocalRandom/current) .nextLong Long/toHexString .toLowerCase))
 
 (defn mime-type-descriptor
@@ -47,7 +50,9 @@
    (when encoding
      (str "; charset=" encoding))))
 
-(defn populate-part
+(defn
+  ^{:deprecated "use aleph.http.multipart/encode-request instead"}
+  populate-part
   "Generates a part map of the appropriate format"
   [{:keys [part-name content mime-type charset transfer-encoding name]}]
   (let [file? (instance? File content)
@@ -79,7 +84,9 @@
 ;;
 ;; Note, that you can use transfer-encoding=nil or :binary to leave data "as is".
 ;; transfer-encoding=nil omits "Content-Transfer-Encoding" header.
-(defn part-headers [^String part-name ^String mime-type transfer-encoding name]
+(defn
+  ^{:deprecated "use aleph.http.multipart/encode-request instead"}
+  part-headers [^String part-name ^String mime-type transfer-encoding name]
   (let [cd (str "Content-Disposition: form-data; name=\"" part-name "\""
              (when name (str "; filename=\"" name "\""))
              "\r\n")
@@ -89,7 +96,9 @@
               (str "Content-Transfer-Encoding: " (cc/name transfer-encoding) "\r\n"))]
     (bs/to-byte-buffer (str cd ct cte "\r\n"))))
 
-(defn encode-part
+(defn
+  ^{:deprecated "use aleph.http.multipart/encode-request instead"}
+  encode-part
   "Generates the byte representation of a part for the bytebuffer"
   [{:keys [part-name content mime-type charset transfer-encoding name] :as part}]
   (let [headers (part-headers part-name mime-type transfer-encoding name)
@@ -162,6 +171,33 @@
     (let [req' (.finalizeRequest encoder)]
       [req' (when (.isChunked encoder) encoder)])))
 
+(defrecord MultipartChunk [part-name
+                           content
+                           name
+                           charset
+                           mime-type
+                           transfer-encoding
+                           memory?
+                           file?
+                           file
+                           size
+                           ^ReferenceCounted raw-http-data]
+  ReferenceCounted
+  (refCnt [_]
+    (.refCnt raw-http-data))
+  (retain [_]
+    (.retain raw-http-data))
+  (retain [_ increment]
+    (.retain raw-http-data increment))
+  (^ReferenceCounted touch [_]
+    (.touch raw-http-data))
+  (^ReferenceCounted touch [_ ^Object hint]
+    (.touch raw-http-data hint))
+  (release [_]
+    (.release raw-http-data))
+  (release [_ decrement]
+    (.release raw-http-data decrement)))
+
 (defmulti http-data->map
   (fn [^InterfaceHttpData data]
     (.getHttpDataType data)))
@@ -169,35 +205,53 @@
 (defmethod http-data->map InterfaceHttpData$HttpDataType/Attribute
   [^Attribute attr]
   (let [content (.getValue attr)]
-    {:part-name (.getName attr)
-     :content content
-     :name nil
-     :charset (-> attr .getCharset .toString)
-     :mime-type nil
-     :transfer-encoding nil
-     :memory? (.isInMemory attr)
-     :file? false
-     :file nil
-     :size (count content)}))
+    (map->MultipartChunk
+     {:part-name (.getName attr)
+      :content content
+      :name nil
+      :charset (-> attr .getCharset .toString)
+      :mime-type nil
+      :transfer-encoding nil
+      :memory? (.isInMemory attr)
+      :file? false
+      :file nil
+      :size (count content)
+      :raw-http-data attr})))
 
 (defmethod http-data->map InterfaceHttpData$HttpDataType/FileUpload
   [^FileUpload data]
   (let [memory? (.isInMemory data)]
-    {:part-name (.getName data)
-     :content (when memory?
-                (bs/to-input-stream (netty/acquire (.content data))))
-     :name (.getFilename data)
-     :charset (-> data .getCharset .toString)
-     :mime-type (.getContentType data)
-     :transfer-encoding (.getContentTransferEncoding data)
-     :memory? memory?
-     :file? true
-     :file (when-not memory? (.getFile data))
-     :size (.length data)}))
+    (map->MultipartChunk
+     {:part-name (.getName data)
+      :content (when memory?
+                 (bs/to-input-stream (netty/acquire (.content data))))
+      :name (.getFilename data)
+      :charset (-> data .getCharset .toString)
+      :mime-type (.getContentType data)
+      :transfer-encoding (.getContentTransferEncoding data)
+      :memory? memory?
+      :file? true
+      :file (when-not memory? (.getFile data))
+      :size (.length data)
+      :raw-http-data data})))
 
 (defn- read-attributes [^HttpPostRequestDecoder decoder parts]
-  (while (.hasNext decoder)
-    (s/put! parts (http-data->map (.next decoder)))))
+  (d/loop []
+    (if-not (.hasNext decoder)
+      (d/success-deferred true) ;; go for another chunk of body
+      (let [^InterfaceHttpData data (.next decoder)]
+        (if (nil? data)
+          ;; this probably could happen only in case of
+          ;; simultaneous access to the decoder object...
+          (d/success-deferred true)
+          (d/chain'
+           (s/put! parts (http-data->map data))
+           (fn [succeed?]
+             (if succeed?
+               (do
+                 (.removeHttpDataFromClean decoder data)
+                 (d/recur))
+               (d/success-deferred false)))))))))
 
 (defn decode-request
   "Takes a ring request and returns a manifold stream which yields
@@ -206,6 +260,32 @@
    corresponding payload would be written to a temp file. Check `:memory?`
    flag to know whether content might be read directly from `:content` or
    should be fetched from the file specified in `:file`.
+
+   Each part should be released using `netty/release` helper to cleanup
+   allocated buffers and temp files (if any) as soon as the data is fully
+   consumed (i.e. temp file moved to a target location). Note, it's also
+   safer to close the stream of chunks manually to ensure all chunks that
+   were never read from the stream but were already consumed from the connection,
+   are also deallocated.
+
+   Typical usage looks like:
+
+   ```
+   (require '[aleph.http.multipart :as multipart])
+   (require '[aleph.netty :as netty])
+   (require '[manifold.stream :as stream])
+   (require '[clojure.java.io :as io])
+
+   (defn file-upload-handler [req]
+     (let [chunks (multipart/decode-request req)]
+       (d/chain'
+         (stream/take! chunks)
+         (fn [{:keys [file] :as chunk}]
+           (io/copy file writer)
+           (netty/release chunk)
+           (stream/close! chunks)
+           {:status 200 :body \"Succesfull!\"}))))
+   ```
 
    Note, that if your handler works with multipart requests only,
    it's better to set `:raw-stream?` to `true` to avoid additional
@@ -232,13 +312,12 @@
       (fn [chunk]
         (let [content (DefaultHttpContent. chunk)]
           (.offer decoder content)
-          (read-attributes decoder parts)
-          ;; note, that releasing chunk right here relies on
-          ;; the internals of the decoder. in case those
-          ;; internal are changed in future, this flow of
-          ;; manipulations should be also reconsidered
+          ;; note, that HttpPostRequestDecoder actually
+          ;; makes a copy of the content provided, so we can
+          ;; release it here
+          ;; https://github.com/netty/netty/blob/d05666ae2d2068da7ee031a8bfc1ca572dbcc3f8/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java#L329
           (netty/release chunk)
-          (d/success-deferred true)))
+          (read-attributes decoder parts)))
       parts)
 
      (s/on-closed
@@ -246,6 +325,11 @@
       (fn []
         (when (compare-and-set! destroyed? false true)
           (try
+            ;; we're removing each received http data chunk
+            ;; from cleanup queue before pushing to `parts` stream,
+            ;; meaning that this `destroy` call would only cleanup
+            ;; those chunck that were not consumed for some reasons
+            ;; (i.e. the user closes the stream given earlier)
             (.destroy decoder)
             (catch Exception e
               (log/warn e "exception when cleaning up multipart decoder"))))))

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -201,47 +201,61 @@
                    (bs/to-string content))]
     (assoc chunk :content content')))
 
-(defn- pack-chunk [{:keys [content] :as chunk}]
+(defn- pack-chunk [chunk]
   (-> chunk
       (coerce-chunk-content)
       (dissoc :file :raw-http-data)))
 
-(defn- decode-handler [req]
-  (let [req' (mp/decode-request req {:memory-limit 12})
-        chunks (s/stream->seq req')
-        body (pr-str (map pack-chunk chunks))]
-    (doseq [{:keys [file content] :as chunk} chunks]
-      ;; we should be able to read file before removal (if any)
-      (when (some? file)
-        (is (some? (slurp (.getAbsolutePath ^java.io.File file)))))
-      (is (netty/release chunk))
-      ;; temp file is now removed (if any)
-      (when (some? file)
-        (is (not (.exists ^java.io.File file)))))
-    {:status 200
-     :body body}))
+(defn- decode-handler [req options]
+  (let [chunks (mp/decode-request req options)]
+    (->
+     (d/loop [body []]
+       (d/chain' (s/take! chunks)
+                 (fn [{:keys [file] :as chunk}]
+                   (Thread/sleep 20)
+                   (if (nil? chunk)
+                     ;; when `chunks` stream has been closed and there is no more
+                     ;; `chunk` left.
+                     body
+                     (let [packed-chunk (pack-chunk chunk)]
+                       ;; we should be able to read file before removal (if any)
+                       (when (some? file)
+                         (is (some? (slurp (.getAbsolutePath ^java.io.File file)))))
+                       (is (netty/release chunk))
+                       ;; temp file is now removed (if any)
+                       (when (some? file)
+                         (is (not (.exists ^java.io.File file))))
+                       (d/recur (conj body packed-chunk)))))))
+     (d/chain'
+      (fn [body]
+        {:status 200
+         :body (pr-str body)})))))
 
-(defn- test-decoder [port url raw-stream?]
-  (let [s (http/start-server decode-handler {:port port
-                                             :raw-stream? raw-stream?})
-        chunks (-> (http/post url {:multipart parts})
-                   (deref 1e3 {:body "timeout"})
-                   :body
-                   bs/to-string
-                   clojure.edn/read-string
-                   vec)]
-    (is (= 6 (count chunks)))
+(defn- test-decoder
+  ([port url]
+   (test-decoder port url {}))
+  ([port url options]
+   (let [handler #(decode-handler % options)
+         s (http/start-server handler (merge {:port port}
+                                             options))
+         chunks (-> (http/post url {:multipart parts})
+                    (deref 1e3 {:body "timeout"})
+                    :body
+                    bs/to-string
+                    clojure.edn/read-string
+                    vec)]
+     (is (= 6 (count chunks)))
 
-    ;; part-names
-    (is (= (map :part-name parts)
-           (map :part-name chunks)))
+     ;; part-names
+     (is (= (map :part-name parts)
+            (map :part-name chunks)))
 
-    ;; content
-    (is (= "CONTENT1" (get-in chunks [0 :content])))
+     ;; content
+     (is (= "CONTENT1" (get-in chunks [0 :content])))
 
-    ;; mime type
-    (is (= "text/plain" (get-in chunks [2 :mime-type])))
-    (is (= "application/png" (get-in chunks [3 :mime-type])))
+     ;; mime type
+     (is (= "text/plain" (get-in chunks [2 :mime-type])))
+     (is (= "application/png" (get-in chunks [3 :mime-type])))
 
     ;; filename
     (is (= "file.txt" (get-in chunks [3 :name])))
@@ -250,10 +264,27 @@
     ;; charset
     (is (= "ISO-8859-1" (get-in chunks [5 :charset])))
 
-    (.close ^java.io.Closeable s)))
+    (.close ^java.io.Closeable s))))
 
 (deftest test-mutlipart-request-decode-with-ring-handler
-  (test-decoder port2 url2 false))
+  (testing "without memory-limit"
+    (test-decoder port2 url2))
+  (testing "with infinite memory-limit"
+    (test-decoder port2 url2 {:memory-limit Long/MAX_VALUE}))
+  (testing "with small memory-limit"
+    (test-decoder port2 url2 {:memory-limit 12}))
+  (testing "with zero memory-limit"
+    (test-decoder port2 url2 {:memory-limit 0})))
 
 (deftest test-mutlipart-request-decode-with-raw-handler
-  (test-decoder port3 url3 true))
+  (testing "without memory-limit"
+    (test-decoder port3 url3 {:raw-stream? true}))
+  (testing "with infinite memory-limit"
+    (test-decoder port3 url3 {:raw-stream? true
+                              :memory-limit Long/MAX_VALUE}))
+  (testing "with small memory-limit"
+    (test-decoder port3 url3 {:raw-stream? true
+                              :memory-limit 12}))
+  (testing "with zero memory-limit"
+    (test-decoder port3 url3 {:raw-stream? true
+                              :memory-limit 0})))


### PR DESCRIPTION
## Description

This PR takes the commits from the `1.0.0` branch related to multipart requests and add
some tests around it : [Attempt to provide correct API for multipart resources management](https://github.com/clj-commons/aleph/pull/432)

Unfortunately, the tests have demonstrated the proposed implementation was still
not working as expected. There is absolutely no guarantee we'll able to read the content
of the stream (the files) before it has been closed and thus the `decoder` destroyed, removing
all the files before we were able to copy them.

~~The proposed fix is actually a __breaking change__ (I don't expect to get it merge as it is but I 
want to raise the discussion).~~
~~- Instead of returning a `manifold.stream`, we return a vector containing the `manifold.stream` 
and a function that can be called to destroy the decoder. That `destroy-decoder-fn` needs to be 
called on a `d/finally` to ensure all the resources have been cleaned up.~~

Here is the related issue : https://github.com/clj-commons/aleph/issues/567

~~As we don't want breaking changes, I guess we'll have to deprecate the `decode-request` function.
I see absolutely no-way to fix the current implementation... It's either we break or we deprecate at that point.~~

I tried to split the commits in three parts:
- The original commit from @kachayev (https://github.com/clj-commons/aleph/pull/596/commits/e67f920acc68fccde25e7448af66118731900e2d)
- Some tests to prove it's not working in some cases (https://github.com/clj-commons/aleph/pull/596/commits/5e20b5d041dccaadbdaaee0ebb44748834c8e6bc)
- ~~Introduce a configurable delay before destroying the decoder :  (https://github.com/clj-commons/aleph/pull/596/commits/0588cd58691ed90b9c3154c7ecd1c71fb37b0ebc)~~
- Ensure all files are removed before calling destroy : https://github.com/clj-commons/aleph/commit/16c9ed3136242a1ef137c6ad91150c3004531c8b

~~What are your thoughts about that?~~
