### PR TITLE
Redirects broken with :method key

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                    (map
                      #(vector (symbol "io.netty" (str "netty-" %)) netty-version)
                      netty-modules))
-  :profiles {:dev  {:dependencies [[org.clojure/clojure "1.10.1"]
+  :profiles {:dev  {:dependencies [[org.clojure/clojure "1.10.3"]
                                    [criterium "0.4.6"]
                                    [cheshire "5.10.0"]
                                    [org.slf4j/slf4j-simple "1.7.30"]

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -276,15 +276,16 @@
      by [clj-http](https://github.com/dakrone/clj-http), and returns a deferred representing
      the HTTP response.  Also allows for a custom `pool` or `middleware` to be defined.
 
-     |:---|:---
-     | `pool` | a custom connection pool
-     | `middleware` | custom client middleware for the request
-     | `pool-timeout` | timeout in milliseconds for the pool to generate a connection
-     | `response-executor` | optional `java.util.concurrent.Executor` that will handle the requests (defaults to a `flow/utilization-executor` of 256 `max-threads` and a `queue-length` of 0)
-     | `connection-timeout` | timeout in milliseconds for the connection to become established
-     | `request-timeout` | timeout in milliseconds for the arrival of a response over the established connection
-     | `read-timeout` | timeout in milliseconds for the response to be completed
-     | `follow-redirects?` | whether to follow redirects, defaults to `true`; see `aleph.http.client-middleware/handle-redirects`"
+     Param key            | Description
+     -------------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------
+     `connection-timeout` | timeout in milliseconds for the connection to become established
+     `follow-redirects?`  | whether to follow redirects, defaults to `true`; see `aleph.http.client-middleware/handle-redirects`
+     `middleware`         | custom client middleware for the request
+     `pool-timeout`       | timeout in milliseconds for the pool to generate a connection
+     `pool`               | a custom connection pool
+     `read-timeout`       | timeout in milliseconds for the response to be completed
+     `request-timeout`    | timeout in milliseconds for the arrival of a response over the established connection
+     `response-executor`  | optional `java.util.concurrent.Executor` that will handle the requests (defaults to a `flow/utilization-executor` of 256 `max-threads` and a `queue-length` of 0)"
     [{:keys [pool
              middleware
              pool-timeout
@@ -292,11 +293,11 @@
              connection-timeout
              request-timeout
              read-timeout]
-      :or {pool default-connection-pool
-           response-executor default-response-executor
-           middleware identity
-           connection-timeout 6e4} ;; 60 seconds
-      :as req}]
+      :or   {pool               default-connection-pool
+             response-executor  default-response-executor
+             middleware         identity
+             connection-timeout 6e4}                        ;; 60 seconds
+      :as   req}]
 
     (executor/with-executor response-executor
       ((middleware
@@ -306,84 +307,81 @@
 
              ;; acquire a connection
              (-> (flow/acquire pool k)
-               (maybe-timeout! pool-timeout)
+                 (maybe-timeout! pool-timeout)
 
-               ;; pool timeout triggered
-               (d/catch' TimeoutException
-                 (fn [^Throwable e]
-                   (d/error-deferred (PoolTimeoutException. e))))
+                 ;; pool timeout triggered
+                 (d/catch' TimeoutException
+                   (fn [^Throwable e]
+                     (d/error-deferred (PoolTimeoutException. e))))
 
-               (d/chain'
-                 (fn [conn]
+                 (d/chain'
+                   (fn [conn]
 
-                   ;; get the wrapper for the connection, which may or may not be realized yet
-                   (-> (first conn)
+                     ;; get the wrapper for the connection, which may or may not be realized yet
+                     (-> (first conn)
+                         (maybe-timeout! connection-timeout)
 
-                     (maybe-timeout! connection-timeout)
+                         ;; connection timeout triggered, dispose of the connetion
+                         (d/catch' TimeoutException
+                           (fn [^Throwable e]
+                             (flow/dispose pool k conn)
+                             (d/error-deferred (ConnectionTimeoutException. e))))
 
-                     ;; connection timeout triggered, dispose of the connetion
-                     (d/catch' TimeoutException
-                       (fn [^Throwable e]
-                         (flow/dispose pool k conn)
-                         (d/error-deferred (ConnectionTimeoutException. e))))
+                         ;; connection failed, bail out
+                         (d/catch'
+                           (fn [e]
+                             (flow/dispose pool k conn)
+                             (d/error-deferred e)))
 
-                     ;; connection failed, bail out
-                     (d/catch'
-                       (fn [e]
-                         (flow/dispose pool k conn)
-                         (d/error-deferred e)))
+                         ;; actually make the request now
+                         (d/chain'
+                           (fn [conn']
+                             (when-not (nil? conn')
+                               (let [end (System/currentTimeMillis)]
+                                 (-> (conn' req)
+                                     (maybe-timeout! request-timeout)
 
-                     ;; actually make the request now
-                     (d/chain'
-
-                       (fn [conn']
-
-                         (when-not (nil? conn')
-                           (let [end (System/currentTimeMillis)]
-                             (-> (conn' req)
-                               (maybe-timeout! request-timeout)
-
-                               ;; request timeout triggered, dispose of the connection
-                               (d/catch' TimeoutException
-                                 (fn [^Throwable e]
-                                   (flow/dispose pool k conn)
-                                   (d/error-deferred (RequestTimeoutException. e))))
-
-                               ;; request failed, dispose of the connection
-                               (d/catch'
-                                 (fn [e]
-                                   (flow/dispose pool k conn)
-                                   (d/error-deferred e)))
-
-                               ;; clean up the response
-                               (d/chain'
-                                 (fn [rsp]
-
-                                   ;; only release the connection back once the response is complete
-                                   (-> (:aleph/complete rsp)
-                                     (maybe-timeout! read-timeout)
-
+                                     ;; request timeout triggered, dispose of the connection
                                      (d/catch' TimeoutException
                                        (fn [^Throwable e]
                                          (flow/dispose pool k conn)
-                                         (d/error-deferred (ReadTimeoutException. e))))
+                                         (d/error-deferred (RequestTimeoutException. e))))
 
+                                     ;; request failed, dispose of the connection
+                                     (d/catch'
+                                       (fn [e]
+                                         (flow/dispose pool k conn)
+                                         (d/error-deferred e)))
+
+                                     ;; clean up the connection
                                      (d/chain'
-                                       (fn [early?]
-                                         (if (or early?
-                                               (not (:aleph/keep-alive? rsp))
-                                               (<= 400 (:status rsp)))
-                                           (flow/dispose pool k conn)
-                                           (flow/release pool k conn)))))
-                                   (-> rsp
-                                     (dissoc :aleph/complete)
-                                     (assoc :connection-time (- end start)))))))))
+                                       (fn cleanup-conn [rsp]
 
-                       (fn [rsp]
-                         (->> rsp
-                           (middleware/handle-cookies req)
-                           (middleware/handle-redirects request req)))))))))))
-        req))))
+                                         ;; only release the connection back once the response is complete
+                                         (-> (:aleph/complete rsp)
+                                             (maybe-timeout! read-timeout)
+
+                                             (d/catch' TimeoutException
+                                               (fn [^Throwable e]
+                                                 (flow/dispose pool k conn)
+                                                 (d/error-deferred (ReadTimeoutException. e))))
+
+                                             (d/chain'
+                                               (fn [early?]
+                                                 (if (or early?
+                                                         (not (:aleph/keep-alive? rsp))
+                                                         (<= 400 (:status rsp)))
+                                                   (flow/dispose pool k conn)
+                                                   (flow/release pool k conn)))))
+                                         (-> rsp
+                                             (dissoc :aleph/complete)
+                                             (assoc :connection-time (- end start)))))))))
+
+                           (fn handle-response [rsp]
+                             (->> rsp
+                                  (middleware/handle-cookies req)
+                                  (middleware/handle-redirects request req)))))))))))
+       req))))
 
 (defn- req
   ([method url]

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -237,7 +237,8 @@
       ssl?
       ch
       (AtomicBoolean. false)
-      (-> req .uri (.indexOf (int 63))) body)
+      (-> req .uri (.indexOf (int 63)))
+      body)
     :aleph/request-arrived (System/nanoTime)))
 
 (defn netty-response->ring-response [rsp complete body]


### PR DESCRIPTION
Fixes #597.

If you just want to see the relevant changes, ignore the first cleanup commit, and look at the second commit.