### PR TITLE
Disable logger when running tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,8 @@
                                    [com.cognitect/transit-clj "1.0.324"]]}
              ;; This is for self-generating certs for testing ONLY:
              :test {:dependencies [[org.bouncycastle/bcprov-jdk15on "1.69"]
-                                   [org.bouncycastle/bcpkix-jdk15on "1.69"]]}}
+                                   [org.bouncycastle/bcpkix-jdk15on "1.69"]]
+                    :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=off"]}}
   :codox {:src-dir-uri "https://github.com/ztellman/aleph/tree/master/"
           :src-linenum-anchor-prefix "L"
           :defaults {:doc/format :markdown}


### PR DESCRIPTION
## Description

Some tests that are testing edge cases log the Exception before
re-throwing it [1][2]. It's not a desired behavior when running the tests.

I propose to disable the logger when running on `test` profile.
An alternative would be to remove the log here, but it would be a breaking change.
In the future, we might be pass a noop `error-logger` when the error handling PR will be merged. https://github.com/clj-commons/aleph/pull/553 

[1] : https://github.com/clj-commons/aleph/blob/36b2859a14fc12cb2665e64f098996115db21852/src/aleph/http/core.clj#L548
[2] : https://github.com/clj-commons/aleph/blob/master/test/aleph/http_test.clj#L276-L281

## Testing done

```
> lein test

lein test aleph.http-continue-test

lein test aleph.http-test

lein test aleph.http.client-middleware-test

lein test aleph.http.client-test

lein test aleph.http.core-test

lein test aleph.http.multipart-test

lein test aleph.ring-test

lein test aleph.tcp-ssl-test

lein test aleph.tcp-test

lein test aleph.udp-test

lein test aleph.websocket-test
```
