### PR TITLE
Ensure IdleStateHandler is the first handler

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -633,7 +633,7 @@
 (defn attach-idle-handlers [^ChannelPipeline pipeline idle-timeout]
   (if (pos? idle-timeout)
     (doto pipeline
-      (.addLast "idle" ^ChannelHandler (IdleStateHandler. 0 0 idle-timeout TimeUnit/MILLISECONDS))
+      (.addFirst "idle" ^ChannelHandler (IdleStateHandler. 0 0 idle-timeout TimeUnit/MILLISECONDS))
       (.addLast "idle-close" ^ChannelHandler (close-on-idle-handler)))
     pipeline))
 

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -633,7 +633,7 @@
 (defn attach-idle-handlers [^ChannelPipeline pipeline idle-timeout]
   (if (pos? idle-timeout)
     (doto pipeline
-      (.addFirst "idle" ^ChannelHandler (IdleStateHandler. 0 0 idle-timeout TimeUnit/MILLISECONDS))
+      (.addLast "idle" ^ChannelHandler (IdleStateHandler. 0 0 idle-timeout TimeUnit/MILLISECONDS))
       (.addLast "idle-close" ^ChannelHandler (close-on-idle-handler)))
     pipeline))
 

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -505,6 +505,7 @@
                                                    ssl?))]
 
       (doto pipeline
+        (http/attach-idle-handlers idle-timeout)
         (.addLast "http-server"
           (HttpServerCodec.
             max-initial-line-length
@@ -517,7 +518,6 @@
             (let [compressor (HttpContentCompressor. (or compression-level 6))]
               (.addAfter ^ChannelPipeline %1 "http-server" "deflater" compressor))
             (.addAfter ^ChannelPipeline %1 "deflater" "streamer" (ChunkedWriteHandler.))))
-        (http/attach-idle-handlers idle-timeout)
         pipeline-transform))))
 
 ;;;

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -510,7 +510,7 @@
         echo-handler (fn [{:keys [body]}] {:body (bs/to-string body)})
         slow-handler (fn [_] {:body (slow-stream)})]
    (testing "Server is slow to write"
-     (with-handler-options slow-handler {:idle-timeout 150
+     (with-handler-options slow-handler {:idle-timeout 200
                                          :port port}
        (is (= "012345" (bs/to-string (:body @(http/get url)))))))
    (testing "Server is too slow to write"
@@ -519,7 +519,7 @@
        (is (= ""
               (bs/to-string (:body @(http/get url)))))))
    (testing "Client is slow to write"
-     (with-handler-options echo-handler {:idle-timeout 150
+     (with-handler-options echo-handler {:idle-timeout 200
                                          :port port
                                          :raw-stream? true}
        (is (= "012345" (bs/to-string (:body @(http/put url {:body (slow-stream)})))))))

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -510,7 +510,7 @@
         echo-handler (fn [{:keys [body]}] {:body (bs/to-string body)})
         slow-handler (fn [_] {:body (slow-stream)})]
    (testing "Server is slow to write"
-     (with-handler-options slow-handler {:idle-timeout 70
+     (with-handler-options slow-handler {:idle-timeout 150
                                          :port port}
        (is (= "012345" (bs/to-string (:body @(http/get url)))))))
    (testing "Server is too slow to write"
@@ -519,7 +519,7 @@
        (is (= ""
               (bs/to-string (:body @(http/get url)))))))
    (testing "Client is slow to write"
-     (with-handler-options echo-handler {:idle-timeout 70
+     (with-handler-options echo-handler {:idle-timeout 150
                                          :port port
                                          :raw-stream? true}
        (is (= "012345" (bs/to-string (:body @(http/put url {:body (slow-stream)})))))))


### PR DESCRIPTION
## Description

This ensures the `IdleStateHandler` is always at the first place on the pipeline.

For the complete history : https://github.com/clj-commons/aleph/pull/511

Here are the most relevant parts of the conversation : 

> Having the idle handlers after the other handlers results in them timing out the connection after the timeout without any consideration of actual traffic. This can lead to a socket being closed while it is still actively being used. Attaching the idle handlers first means that a connection will only be treated as idle if no traffic has been sent through the socket for a given period of time.

> This is leading a problem in production for us, where Aleph would terminate connections while a request was in-flight (~20ms after receiving the data) because the connection was older than the request. We have disabled the idle-timeout to get things working for now, but this change will fix things properly.

> In our case, we were seeing the connecting being closed at exactly the idle timeout, every time. We set the idle timeout to 65 seconds, then opened a telnet connection and constantly sent requests and received responses. After 65 seconds the connection was closed, no matter what.

> We're fine with imprecise tracking of the idle timeout, as long as there's some tracking of actual traffic.