### PR TITLE
add pool customization options

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -103,8 +103,8 @@
    | `control-period` | the interval, in milliseconds, between use of the controller to adjust the size of the pool, defaults to `60000`
    | `dns-options` | an optional map with async DNS resolver settings, for more information check `aleph.netty/dns-resolver-group`. When set, ignores `name-resolver` setting from `connection-options` in favor of shared DNS resolver instance
    | `middleware` | a function to modify request before sending, defaults to `aleph.http.client-middleware/wrap-request`
-   | `pool-builder-fn` | a one arity function which returns a `io.aleph.dirigiste.IPool` from a map containing the following keys: `generate`, `destroy`, `control-period`, `max-queue-length` and `stats-callback`.
-   | `pool-controller-builder-fn` | a zero arity function which returns a `io.aleph.dirigiste.IPool$Controller`.
+   | `pool-builder-fn` | an optional one arity function which returns a `io.aleph.dirigiste.IPool` from a map containing the following keys: `generate`, `destroy`, `control-period`, `max-queue-length` and `stats-callback`.
+   | `pool-controller-builder-fn` | an optional zero arity function which returns a `io.aleph.dirigiste.IPool$Controller`.
 
    the `connection-options` are a map describing behavior across all connections:
 


### PR DESCRIPTION
It might not be the best way to add such customisation, as it clashes with other fields (total-connections, target-utilization, max-queue-size, stats-callback) but it should work.

The rationale of this change is to add possibility to pick your own pool implementation. In my case dirigiste pool does not work due to memory leak in 
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/6578505/173294789-9be337d7-f9ea-4ead-b4fc-ae6b62758ce0.png">
