### PR TITLE
Improve TCP+SSL server connection handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Make TCP+SSL server call handler only after successful SSL handshake
+
 ### 0.5.0
 
 * Add initial clj-kondo hooks

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -82,7 +82,7 @@
    |:---|:-----
    | `port` | the port the server will bind to.  If `0`, the server will bind to a random port.
    | `socket-address` | a `java.net.SocketAddress` specifying both the port and interface to bind to.
-   | `ssl-context` | an `io.netty.handler.ssl.SslContext` object. If a self-signed certificate is all that's required, `(aleph.netty/self-signed-ssl-context)` will suffice.
+   | `ssl-context` | an `io.netty.handler.ssl.SslContext` object. If given, the server will only accept SSL connections and call the handler once the SSL session has been successfully established. If a self-signed certificate is all that's required, `(aleph.netty/self-signed-ssl-context)` will suffice.
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it.
    | `pipeline-transform` | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `raw-stream?` | if true, messages from the stream will be `io.netty.buffer.ByteBuf` objects rather than byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users."


### PR DESCRIPTION
When starting an TCP+SSL server, the handler would be called when the
underlying TCP connection is established but before the SSL handshake
has taken place.  At that point, the client's `:ssl-session` value is
still a placeholder (e.g. `.isValid` returns `false`, the cipher suite
is reported as `"SSL_NULL_WITH_NULL_NULL"` and the peer principal is
not available). Also, the stream is not ready for use, so any writes
would be buffered until after the handshake is complete. Since there
is no way to be notified of the handshake completion, the existing
test case worked around this by looking up the SSL session only after
having received a message for the first time which implies that the
session has been successfully established since. However, this is a
pretty awkward API and only works for protocols in which the client
actually is the first to transmit anything. There's also a bit of a
gotcha: The value of `:ssl-session` mutably changes to a different
value after the handshake, so holding on to the initial placeholder
value and only starting to use it later won't do the trick.

This patch changes the semantics so that the handler is only invoked
after the session was successfully established. While technically a
breaking change, it appears unlikely that any existing users would
rely on the original behavior since the placeholder SSL session value
is pretty much useless. The new behavior should be more in line with
user expectation and arguably is more correct (e.g. the handler
doesn't have to wait for I/O before being able to peruse the SSL
session info).

----

FWIW I find the API for looking up `:ssl-session` a bit questionable: It's using `def-derived-map` to dispatch to a method call under the hood whose return value's identity may change over time which is pretty non-obvious and probably not how `def-derived-map` is intended to be used. Then again, with my patch applied, this shouldn't be the case anymore, so I chose to keep it minimally invasive. But something to keep in mind ...