### PR TITLE
Add classifier to netty-transport-native-epoll dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,13 +2,20 @@
 
 (def netty-modules
   '[transport
-    transport-native-epoll
+    [transport-native-epoll "linux-x86_64"]
     codec
     codec-http
     handler
     handler-proxy
     resolver
     resolver-dns])
+
+(defn netty-module [version name]
+  (let [[name classifier] (if (vector? name) name [name nil])
+        s (symbol "io.netty" (str "netty-" name))]
+    (if (nil? classifier)
+      (vector s version)
+      (vector s version :classifier classifier))))
 
 (def other-dependencies
   '[[org.clojure/tools.logging "1.1.0" :exclusions [org.clojure/clojure]]
@@ -26,9 +33,7 @@
   :license {:name "MIT License"}
   :dependencies ~(concat
                    other-dependencies
-                   (map
-                     #(vector (symbol "io.netty" (str "netty-" %)) netty-version)
-                     netty-modules))
+                   (map (partial netty-module netty-version) netty-modules))
   :profiles {:dev  {:dependencies [[org.clojure/clojure "1.10.3"]
                                    [criterium "0.4.6"]
                                    [cheshire "5.10.0"]

--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,7 @@
                  [potemkin "0.4.5"]
                  [io.netty/netty-transport ~netty-version]
                  [io.netty/netty-transport-native-epoll ~netty-version :classifier "linux-x86_64"]
+                 [io.netty/netty-transport-native-epoll ~netty-version :classifier "linux-aarch_64"]
                  [io.netty/netty-codec ~netty-version]
                  [io.netty/netty-codec-http ~netty-version]
                  [io.netty/netty-handler ~netty-version]

--- a/project.clj
+++ b/project.clj
@@ -1,39 +1,25 @@
 (def netty-version "4.1.74.Final")
 
-(def netty-modules
-  '[transport
-    [transport-native-epoll "linux-x86_64"]
-    codec
-    codec-http
-    handler
-    handler-proxy
-    resolver
-    resolver-dns])
-
-(defn netty-module [version name]
-  (let [[name classifier] (if (vector? name) name [name nil])
-        s (symbol "io.netty" (str "netty-" name))]
-    (if (nil? classifier)
-      (vector s version)
-      (vector s version :classifier classifier))))
-
-(def other-dependencies
-  '[[org.clojure/tools.logging "1.1.0" :exclusions [org.clojure/clojure]]
-    [org.clj-commons/dirigiste "1.0.1"]
-    [manifold "0.2.4"]
-    [org.clj-commons/byte-streams "0.3.1"]
-    [org.clj-commons/primitive-math "1.0.0"]
-    [potemkin "0.4.5"]])
-
 (defproject aleph (or (System/getenv "PROJECT_VERSION") "0.5.0")
   :description "A framework for asynchronous communication"
   :repositories {"jboss" "https://repository.jboss.org/nexus/content/groups/public/"
                  "sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}
   :url "https://github.com/clj-commons/aleph"
   :license {:name "MIT License"}
-  :dependencies ~(concat
-                   other-dependencies
-                   (map (partial netty-module netty-version) netty-modules))
+  :dependencies [[org.clojure/tools.logging "1.1.0" :exclusions [org.clojure/clojure]]
+                 [org.clj-commons/dirigiste "1.0.1"]
+                 [manifold "0.2.4"]
+                 [org.clj-commons/byte-streams "0.3.1"]
+                 [org.clj-commons/primitive-math "1.0.0"]
+                 [potemkin "0.4.5"]
+                 [io.netty/netty-transport ~netty-version]
+                 [io.netty/netty-transport-native-epoll ~netty-version :classifier "linux-x86_64"]
+                 [io.netty/netty-codec ~netty-version]
+                 [io.netty/netty-codec-http ~netty-version]
+                 [io.netty/netty-handler ~netty-version]
+                 [io.netty/netty-handler-proxy ~netty-version]
+                 [io.netty/netty-resolver ~netty-version]
+                 [io.netty/netty-resolver-dns ~netty-version]]
   :profiles {:dev  {:dependencies [[org.clojure/clojure "1.10.3"]
                                    [criterium "0.4.6"]
                                    [cheshire "5.10.0"]

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -46,7 +46,7 @@
    | `max-initial-line-length` | the maximum characters that can be in the initial line of the request, defaults to `8192`
    | `max-header-size` | the maximum characters that can be in a single header entry of a request, defaults to `8192`
    | `max-chunk-size` | the maximum characters that can be in a single chunk of a streamed request, defaults to `16384`
-   | `epoll?` | if `true`, uses `epoll` when available, defaults to `false`
+   | `epoll?` | if `true`, uses `epoll`, defaults to `false`.
    | `compression?` | when `true` enables http compression, defaults to `false`
    | `compression-level` | optional compression level, `1` yields the fastest compression and `9` yields the best compression, defaults to `6`. When set, enables http content compression regardless of the `compression?` flag value
    | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds
@@ -115,7 +115,7 @@
    | `response-buffer-size` | the amount of the response, in bytes, that is buffered before the request returns, defaults to `65536`.  This does *not* represent the maximum size response that the client can handle (which is unbounded), and is only a means of maximizing performance.
    | `keep-alive?` | if `true`, attempts to reuse connections for multiple requests, defaults to `true`.
    | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds.
-   | `epoll?` | if `true`, uses `epoll` when available, defaults to `false`
+   | `epoll?` | if `true`, uses `epoll`, defaults to `false`
    | `raw-stream?` | if `true`, bodies of responses will not be buffered at all, and represented as Manifold streams of `io.netty.buffer.ByteBuf` objects rather than as an `InputStream`.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
    | `max-initial-line-length` | the maximum length of the initial line (e.g. HTTP/1.0 200 OK), defaults to `65536`
    | `max-header-size` | the maximum characters that can be in a single header entry of a response, defaults to `65536`
@@ -216,7 +216,7 @@
    | `max-frame-payload` | maximum allowable frame payload length, in bytes, defaults to `65536`.
    | `max-frame-size` | maximum aggregate message size, in bytes, defaults to `1048576`.
    | `bootstrap-transform` | an optional function that takes an `io.netty.bootstrap.Bootstrap` object and modifies it.
-   | `epoll?` | if `true`, uses `epoll` when available, defaults to `false`
+   | `epoll?` | if `true`, uses `epoll`, defaults to `false`
    | `heartbeats` | optional configuration to send Ping frames to the server periodically (if the connection is idle), configuration keys are `:send-after-idle` (in milliseconds), `:payload` (optional, empty frame by default) and `:timeout` (optional, to close the connection if Pong is not received after specified timeout)."
   ([url]
     (websocket-client url nil))

--- a/src/aleph/udp.clj
+++ b/src/aleph/udp.clj
@@ -34,15 +34,17 @@
    | `socket-address` | a `java.net.SocketAddress` specifying both the port and interface to bind to.
    | `broadcast?` | if true, all UDP datagrams are broadcast.
    | `bootstrap-transform` | a function which takes the Netty `Bootstrap` object, and makes any desired changes before it's bound to a socket.
-   | `raw-stream?` | if true, the `:message` within each packet will be `io.netty.buffer.ByteBuf` objects rather than byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users."
+   | `raw-stream?` | if true, the `:message` within each packet will be `io.netty.buffer.ByteBuf` objects rather than byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
+   | `epoll?` | if `true`, uses `epoll`, defaults to `false`"
   [{:keys [socket-address port broadcast? raw-stream? bootstrap-transform epoll?]
     :or {epoll? false
          broadcast? false
          raw-stream? false
          bootstrap-transform identity}}]
+  (when epoll?
+    (netty/ensure-epoll-available!))
   (let [in (atom nil)
         d (d/deferred)
-        epoll? (and epoll? (netty/epoll-available?))
         g (if epoll?
             @netty/epoll-client-group
             @netty/nio-client-group)


### PR DESCRIPTION
Fixes #475.

This is a cherry-pick of 5f5e73b256027d3d887582118af86b580eb08b0c from the `1.0.0` branch minus the `kqueue`-related changes.