### PR TITLE
Fix #617 and #618

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -232,9 +232,7 @@
      (d/error! d (CancellationException. "future is cancelled."))
 
      (some? (.cause f))
-     (if (instance? ClosedChannelException (.cause f))
-       (d/success! d false)
-       (d/error! d (.cause f)))
+     (d/error! d (.cause f))
 
      :else
      (d/error! d (IllegalStateException. "future in unknown state"))))

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -53,8 +53,8 @@
 
       :channel-inactive
       ([_ ctx]
-        (s/close! @in)
-        (.fireChannelInactive ctx))
+       (some-> @in s/close!)
+       (.fireChannelInactive ctx))
 
       :channel-active
       ([_ ctx]

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -62,8 +62,12 @@
          (-> ssl-handler
              .handshakeFuture
              netty/wrap-future
-             (d/on-realized (fn [_]
-                              (call-handler ctx))
+             (d/on-realized (fn [ok?]
+                              ;; See
+                              ;; https://github.com/clj-commons/aleph/issues/618
+                              ;; for why this conditional is necessary
+                              (when ok?
+                                (call-handler ctx)))
                             ;; No need to handle errors here since
                             ;; the SSL handler will terminate the
                             ;; whole pipeline by throwing a

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -62,12 +62,8 @@
          (-> ssl-handler
              .handshakeFuture
              netty/wrap-future
-             (d/on-realized (fn [ok?]
-                              ;; See
-                              ;; https://github.com/clj-commons/aleph/issues/618
-                              ;; for why this conditional is necessary
-                              (when ok?
-                                (call-handler ctx)))
+             (d/on-realized (fn [_]
+                              (call-handler ctx))
                             ;; No need to handle errors here since
                             ;; the SSL handler will terminate the
                             ;; whole pipeline by throwing a

--- a/test/aleph/netty_test.clj
+++ b/test/aleph/netty_test.clj
@@ -1,0 +1,14 @@
+(ns aleph.netty-test
+  (:require
+   [aleph.netty :as netty]
+   [clojure.test :refer [deftest is]]
+   [manifold.stream :as s])
+  (:import
+   (io.netty.channel.embedded EmbeddedChannel)))
+
+(deftest closing-a-channel-sink
+  (let [ch (EmbeddedChannel.)
+        s (netty/sink ch)]
+    (is (= true @(s/put! s "foo")))
+    (is (nil? @(netty/wrap-future (netty/close ch))))
+    (is (= false @(s/put! s "foo")))))

--- a/test/aleph/ssl.clj
+++ b/test/aleph/ssl.clj
@@ -2,7 +2,6 @@
   (:require
    [aleph.netty :as netty])
   (:import
-   (io.netty.handler.ssl ClientAuth SslContextBuilder)
    (java.io ByteArrayInputStream)
    (java.security KeyFactory PrivateKey)
    (java.security.cert CertificateFactory X509Certificate)

--- a/test/aleph/tcp_ssl_test.clj
+++ b/test/aleph/tcp_ssl_test.clj
@@ -61,3 +61,22 @@
                                            :trust-store (into-array X509Certificate [ssl/ca-cert])})})]
         (is (nil? @(s/take! c)))
         (is (nil? @ssl-session) "SSL session should be undefined")))))
+
+(deftest test-connection-close-during-ssl-handshake
+  (let [ssl-session (atom nil)
+        connection-closed (promise)
+        notify-connection-closed (netty/channel-handler
+                                  :channel-inactive
+                                  ([_ ctx]
+                                   (deliver connection-closed true)
+                                   (.fireChannelInactive ctx)))]
+    (with-server (tcp/start-server (ssl-echo-handler ssl-session)
+                                   {:port 10001
+                                    :ssl-context ssl/server-ssl-context
+                                    :pipeline-transform (fn [p]
+                                                          (.addLast p notify-connection-closed))})
+      (let [c @(tcp/client {:host "localhost"
+                            :port 10001})]
+        (s/close! c)
+        (is (deref connection-closed 1000 false))
+        (is (nil? @ssl-session) "SSL session should be undefined")))))

--- a/test/aleph/tcp_ssl_test.clj
+++ b/test/aleph/tcp_ssl_test.clj
@@ -65,11 +65,11 @@
 (deftest test-connection-close-during-ssl-handshake
   (let [ssl-session (atom nil)
         connection-closed (promise)
-        notify-connection-closed (netty/channel-handler
-                                  :channel-inactive
-                                  ([_ ctx]
-                                   (deliver connection-closed true)
-                                   (.fireChannelInactive ctx)))]
+        notify-connection-closed #_:clj-kondo/ignore (netty/channel-handler
+                                                      :channel-inactive
+                                                      ([_ ctx]
+                                                       (deliver connection-closed true)
+                                                       (.fireChannelInactive ctx)))]
     (with-server (tcp/start-server (ssl-echo-handler ssl-session)
                                    {:port 10001
                                     :ssl-context ssl/server-ssl-context


### PR DESCRIPTION
Went for both because I had to fix #617 for being able to construct the regression test case for #618. Without it, the `:channel-inactive` event would not be propagated to the `notify-connection-closed` handler.