### PR TITLE
Update Netty to 4.1.79.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.74.Final")
+(def netty-version "4.1.79.Final")
 
 (defproject aleph (or (System/getenv "PROJECT_VERSION") "0.5.0")
   :description "A framework for asynchronous communication"


### PR DESCRIPTION
4.1.77.Final shipped a fix for CVE-2022-24823. While that
vulnerability only affects Java 6 and lower which Clojure doesn't even
support, it's still reported by tools like `nvd-clojure`. Thus,
bumping to the latest minor version relieves downstream users from
having to suppress such false positives.

Also included are various smaller bug fixes and improvements. A
selection of particularly interesting ones for Aleph users:

* https://github.com/netty/netty/pull/12108
* https://github.com/netty/netty/pull/12246
* https://github.com/netty/netty/pull/12270
* https://github.com/netty/netty/pull/12476
* https://github.com/netty/netty/pull/12490
* https://github.com/netty/netty/pull/12533


FWIW: We've been running on 4.1.77.Final in production for about 3 months now without trouble and 4.1.79.Final for about 1 month in staging.