### PR TITLE
Improve short-circuiting behavior of `wrap-future`

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -243,10 +243,10 @@
     (let [d (d/deferred nil)]
       (if (.isDone f)
         (operation-complete f d)
-        (let [;; Ensure the same bindings are installed on the Netty thread (vars,
-              ;; classloader) than the thread registering the
-              ;; `operationComplete` callback.
-              bound-operation-complete (bound-fn* operation-complete)]
+        ;; Ensure the same bindings are installed on the Netty thread (vars,
+        ;; classloader) than the thread registering the
+        ;; `operationComplete` callback.
+        (let [bound-operation-complete (bound-fn* operation-complete)]
           (.addListener f
                         (reify GenericFutureListener
                           (operationComplete [_ _]


### PR DESCRIPTION
If the Netty future passed to `wrap-future` is already done, resolve
the deferred result immediately. This short-circuits the Netty future
listener indirection and all the overhead it involves in such a
situation.

Note that this optimization was already partially implemented, namely
for the success case. This patch merely generelizes it to all "done"
cases.

Fixes #614.