### PR TITLE
Only yield client streams after successful SSL handshake

### DIFF
--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -680,9 +680,12 @@
 
        :channel-active
        ([_ ctx]
-        (let [ch (.channel ctx)]
-          (reset! in (netty/buffered-source ch (constantly 1) 16))
-          (.handshake handshaker ch))
+        (-> (.channel ctx)
+            netty/maybe-ssl-handshake-future
+            (d/on-realized (fn [ch]
+                             (reset! in (netty/buffered-source ch (constantly 1) 16))
+                             (.handshake handshaker ch))
+                           netty/ignore-ssl-handshake-errors))
         (.fireChannelActive ctx))
 
        :user-event-triggered


### PR DESCRIPTION
The deferred returned by `aleph.tcp/client` would always be resolved as soon as the TCP connection was established, even when a `:ssl-context` was given and the SSL handshake had not yet taken place. With this patch, it will only be resolved once the SSL handshake was successful.

Unfortunately, since TLSv1.3 the connection may still fail with a handshake error even after the handshake has seemingly succeeded. This is because only an invalid certificate is explicitly rejected while a valid certificate will be implicitly accepted. Thus, it's only possible to determine whether the handshake has fully succeeded after having succeessfully read some data. See [1] and [2] for more details. However, this patch still seems worhtwhile even for TLSv1.3 since the stream is only yielded at the earliest time it would theoretically be possible to successfully use it.

This patch is the client-side dual of
9c911e37f305f3392b5b0c57156eff4c16bc8dc2 and as such, the common code is extracted into a `on-connection-established` helper.

1: https://github.com/netty/netty/issues/10502
2: https://stackoverflow.com/questions/62459802/tls-1-3-client-does-not-report-failed-handshake-when-client-certificate-verifica/62465859#62465859