### PR TITLE
Add minimal tools.deps support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,5 +37,7 @@ jobs:
             - ~/.m2
           key: v1-dependencies-{{ checksum "project.clj" }}
 
+      - run: deps/ensure-deps-up-to-date
+
       # run tests!
       - run: lein do clean, test

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @arnaudgeiser @kingmob
+* @arnaudgeiser @kingmob @dergutemoritz
+/deps/ @dergutemoritz

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Where incoming packets will have a `:message` that is a byte-array, which can be
 
 To learn more, [read the documentation](http://aleph.io/examples/literate.html).
 
+### Development
+
+Aleph uses [Leinigen](https://leiningen.org/) for managing dependencies, running REPLs and tests, and building the code.
+
+Minimal [`tools.deps`](https://github.com/clojure/tools.deps.alpha) support is available in the form of a `deps.edn` file which is generated from `project.clj`. It provides just enough to be able to use Aleph as a git or `:local/root` dependency. When committing changes to `project.clj`, run `deps/lein-to-deps` and commit the resulting changes, too.
+
 ### License
 
 Copyright © 2010-2020 Zachary Tellman

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To learn more, [read the documentation](http://aleph.io/examples/literate.html).
 
 ### Development
 
-Aleph uses [Leinigen](https://leiningen.org/) for managing dependencies, running REPLs and tests, and building the code.
+Aleph uses [Leiningen](https://leiningen.org/) for managing dependencies, running REPLs and tests, and building the code.
 
 Minimal [`tools.deps`](https://github.com/clojure/tools.deps.alpha) support is available in the form of a `deps.edn` file which is generated from `project.clj`. It provides just enough to be able to use Aleph as a git or `:local/root` dependency. When committing changes to `project.clj`, run `deps/lein-to-deps` and commit the resulting changes, too.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Leiningen:
 deps.edn:
 ```clojure
 aleph/aleph {:mvn/version "0.5.0"}
+;; alternatively
+io.github.clj-commons/aleph {:git/sha "..."}
 ```
 
 ### HTTP

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,31 @@
+;; DO NOT EDIT MANUALLY - generated from project.clj via deps/lein-to-deps
+{:paths ["src/" "target/classes/"],
+ :deps
+ {org.clojure/tools.logging
+  {:mvn/version "1.1.0", :exclusions [org.clojure/clojure]},
+  io.netty/netty-handler-proxy {:mvn/version "4.1.79.Final"},
+  manifold/manifold {:mvn/version "0.2.4"},
+  io.netty/netty-codec {:mvn/version "4.1.79.Final"},
+  io.netty/netty-transport-native-epoll$linux-aarch_64
+  {:mvn/version "4.1.79.Final"},
+  org.clj-commons/dirigiste {:mvn/version "1.0.1"},
+  io.netty/netty-handler {:mvn/version "4.1.79.Final"},
+  org.clj-commons/primitive-math {:mvn/version "1.0.0"},
+  io.netty/netty-transport-native-epoll$linux-x86_64
+  {:mvn/version "4.1.79.Final"},
+  io.netty/netty-transport {:mvn/version "4.1.79.Final"},
+  org.clj-commons/byte-streams {:mvn/version "0.3.1"},
+  io.netty/netty-codec-http {:mvn/version "4.1.79.Final"},
+  potemkin/potemkin {:mvn/version "0.4.5"},
+  io.netty/netty-resolver {:mvn/version "4.1.79.Final"},
+  io.netty/netty-resolver-dns {:mvn/version "4.1.79.Final"}},
+ :aliases
+ {:build
+  {:paths ["deps"],
+   :deps
+   {io.github.clojure/tools.build
+    {:git/sha "cde5adf5d56fe7238de509339e63627f438e5d4b",
+     :git/url "https://github.com/clojure/tools.build.git"}},
+   :ns-default aleph.build}},
+ :deps/prep-lib
+ {:ensure "target/classes/", :alias :build, :fn compile-java}}

--- a/deps/aleph/build.clj
+++ b/deps/aleph/build.clj
@@ -1,0 +1,8 @@
+(ns aleph.build
+  (:require [clojure.tools.build.api :as b]))
+
+(def basis (b/create-basis {:project "deps.edn"}))
+(def build-edn (read-string (slurp "deps/aleph/build.edn")))
+
+(defn compile-java [_]
+  (b/javac (assoc (:javac build-edn) :basis basis)))

--- a/deps/aleph/build.clj
+++ b/deps/aleph/build.clj
@@ -1,6 +1,10 @@
 (ns aleph.build
   (:require [clojure.tools.build.api :as b]))
 
+;; WARNING: This is *not* Aleph's official build process. It merely
+;; replicates a subset of the official Leiningen-based build process
+;; to allow Aleph to be used as a git or local root dependency.
+
 (def basis (b/create-basis {:project "deps.edn"}))
 (def build-edn (read-string (slurp "deps/aleph/build.edn")))
 

--- a/deps/aleph/build.edn
+++ b/deps/aleph/build.edn
@@ -1,0 +1,5 @@
+;; DO NOT EDIT MANUALLY - generated from project.clj via deps/lein-to-deps
+{:javac
+ {:src-dirs ["src/aleph/utils/"],
+  :class-dir "target/classes/",
+  :javac-opts ["-target" "1.8" "-source" "1.8"]}}

--- a/deps/aleph/lein_to_deps.clj
+++ b/deps/aleph/lein_to_deps.clj
@@ -1,0 +1,57 @@
+(ns aleph.lein-to-deps
+  (:require
+   [clojure.java.io :as io]
+   [clojure.pprint :as pp]))
+
+(defn convert-lein-deps [deps]
+  (into {}
+        (map (fn [[name version & {:keys [classifier exclusions]}]]
+               (let [name (if classifier
+                            (symbol (str name "$" classifier))
+                            name)
+                     params (cond-> {:mvn/version version}
+                              (seq exclusions)
+                              (assoc :exclusions (mapv first exclusions)))]
+                 [name params])))
+        deps))
+
+(defn relativize-path [p]
+  (-> (System/getProperty "user.dir")
+      io/file
+      .toURI
+      (.relativize (-> p io/file .toURI))
+      .getPath))
+
+(defn write-edn-file [path data]
+  (binding [*print-namespace-maps* false]
+    (with-open [w (io/writer (io/file path))]
+      (binding [*out* w]
+        (println ";; DO NOT EDIT MANUALLY - generated from project.clj via deps/lein-to-deps")
+        (pp/pprint data)))))
+
+(defn run []
+  (let [pprinted-project-clj (read-string (slurp *in*))
+        deps (convert-lein-deps (:dependencies pprinted-project-clj))
+        class-dir (relativize-path (:compile-path pprinted-project-clj))
+        source-paths (conj (mapv relativize-path (:source-paths pprinted-project-clj))
+                           class-dir)
+        java-source-dirs (mapv relativize-path (:java-source-paths pprinted-project-clj))]
+    (write-edn-file "deps.edn"
+                    {:paths source-paths
+                     :deps deps
+                     :aliases
+                     {:build
+                      {:paths ["deps"]
+                       :deps
+                       {'io.github.clojure/tools.build
+                        {:git/sha "cde5adf5d56fe7238de509339e63627f438e5d4b"
+                         :git/url "https://github.com/clojure/tools.build.git"}},
+                       :ns-default 'aleph.build}}
+                     :deps/prep-lib
+                     {:ensure class-dir
+                      :alias :build
+                      :fn 'compile-java}})
+    (write-edn-file "deps/aleph/build.edn"
+                    {:javac {:src-dirs java-source-dirs
+                             :class-dir class-dir
+                             :javac-opts (:javac-options pprinted-project-clj)}})))

--- a/deps/ensure-deps-up-to-date
+++ b/deps/ensure-deps-up-to-date
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEPS_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
+
+"${DEPS_DIR}/lein-to-deps"
+
+for f in deps.edn deps/aleph/build.edn; do
+    if ! git diff --exit-code "$f"; then
+        echo >&2
+        echo "ERROR: ${f} needs to be re-generated via deps/lein-to-deps" >&2
+        exit 1
+    fi
+done

--- a/deps/lein-to-deps
+++ b/deps/lein-to-deps
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname -- "${BASH_SOURCE[0]}")/.."
+
+lein with-profiles -default pprint | lein with-profiles +lein-to-deps run -m aleph.lein-to-deps/run

--- a/project.clj
+++ b/project.clj
@@ -28,6 +28,7 @@
                                    [com.cognitect/transit-clj "1.0.324"]
                                    [spootnik/signal "0.2.4"]
                                    [me.mourjo/dynamic-redef "0.1.0"]]}
+             :lein-to-deps {:source-paths ["deps"]}
              ;; This is for self-generating certs for testing ONLY:
              :test {:dependencies [[org.bouncycastle/bcprov-jdk15on "1.69"]
                                    [org.bouncycastle/bcpkix-jdk15on "1.69"]]
@@ -43,6 +44,7 @@
   :plugins [[lein-codox "0.10.7"]
             [lein-jammin "0.1.1"]
             [lein-marginalia "0.9.1"]
+            [lein-pprint "1.3.2"]
             [ztellman/lein-cljfmt "0.1.10"]]
   :java-source-paths ["src/aleph/utils"]
   :cljfmt {:indents {#".*" [[:inner 0]]}}


### PR DESCRIPTION
Just enough to allow using aleph as a git dependency via tools.deps. Both the deps.edn file and build.clj's inputs are generated from project.clj which remains the source of truth for now. Can be used as a starting point for a potential full switch to tools.deps in the future.

Also included is a script for re-generating these files, as well as a CI check which should ensure that the generated files don't diverge. Note that these are intentionally not written as tools.deps or babashka tasks so as not to introduce additional dev and build dependencies.

----

FWIW, I've already tested this in practice, too.

Let me know if you have any ideas for improvement or disagree with e.g. the naming or the `deps` directory structure :pray: 