### PR TITLE
dependency: bouncycastle must be a dev dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,8 +30,8 @@
                                    [spootnik/signal "0.2.4"]
                                    [me.mourjo/dynamic-redef "0.1.0"]
                                    ;; This is for self-generating certs for testing ONLY:
-                                   [org.bouncycastle/bcprov-jdk15on "1.69"]
-                                   [org.bouncycastle/bcpkix-jdk15on "1.69"]]
+                                   [org.bouncycastle/bcprov-jdk18on "1.72"]
+                                   [org.bouncycastle/bcpkix-jdk18on "1.72"]]
                     :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"]}
              :lein-to-deps {:source-paths ["deps"]}
              :test {:jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=off"]}}

--- a/project.clj
+++ b/project.clj
@@ -28,12 +28,13 @@
                                    [org.slf4j/slf4j-simple "1.7.30"]
                                    [com.cognitect/transit-clj "1.0.324"]
                                    [spootnik/signal "0.2.4"]
-                                   [me.mourjo/dynamic-redef "0.1.0"]]}
-             :lein-to-deps {:source-paths ["deps"]}
-             ;; This is for self-generating certs for testing ONLY:
-             :test {:dependencies [[org.bouncycastle/bcprov-jdk15on "1.69"]
+                                   [me.mourjo/dynamic-redef "0.1.0"]
+                                   ;; This is for self-generating certs for testing ONLY:
+                                   [org.bouncycastle/bcprov-jdk15on "1.69"]
                                    [org.bouncycastle/bcpkix-jdk15on "1.69"]]
-                    :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=off"]}}
+                    :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"]}
+             :lein-to-deps {:source-paths ["deps"]}
+             :test {:jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=off"]}}
   :codox {:src-dir-uri "https://github.com/ztellman/aleph/tree/master/"
           :src-linenum-anchor-prefix "L"
           :defaults {:doc/format :markdown}


### PR DESCRIPTION
## Description

Aleph cannot be compiled on Java > 9 when `bouncycastle` is not included as a dependency. [1]
As `lein test` loads both the `dev` and `test` profile, everything is fine.
However, a REPL without `with-profile +test` results on `bouncycastle` not being
included which fallback to  `OpenJdkSelfSignedCertGenerator` and thus :

```
Execution error (IllegalAccessError) at io.netty.handler.ssl.util.OpenJdkSelfSignedCertGenerator/generate (OpenJdkSelfSignedCertGenerator.java:52).
class io.netty.handler.ssl.util.OpenJdkSelfSignedCertGenerator (in unnamed module @0x3bb50eaa) cannot access class sun.security.x509.X509CertInfo (in module java.base) because module java.base does not export sun.security.x509 to unnamed module @0x3bb50eaa
```

Let's add `bouncycastle` as a `dev` dependency instead.
To help diagnose this issue, I also changed `-Dorg.slf4j.simpleLogger.defaultLogLevel=debug` on `:dev` profile.

[1] : https://github.com/netty/netty/blob/4.1/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java#L238-L255