### PR TITLE
Pin babashka version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run:
           name: Install bb
           command: |
-            sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
+            sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/3d916df4a0c1e00df94100860b8eb5577e59c56a/install)
 
       - run: lein deps
 

--- a/deps.edn
+++ b/deps.edn
@@ -3,27 +3,28 @@
  :deps
  {org.clojure/tools.logging
   {:mvn/version "1.1.0", :exclusions [org.clojure/clojure]},
-  io.netty/netty-handler-proxy {:mvn/version "4.1.82.Final"},
-  manifold/manifold {:mvn/version "0.2.4"},
-  io.netty/netty-codec {:mvn/version "4.1.82.Final"},
+  io.netty/netty-handler-proxy #:mvn{:version "4.1.82.Final"},
+  manifold/manifold #:mvn{:version "0.2.4"},
+  io.netty/netty-codec #:mvn{:version "4.1.82.Final"},
   io.netty/netty-transport-native-epoll$linux-aarch_64
-  {:mvn/version "4.1.82.Final"},
-  org.clj-commons/dirigiste {:mvn/version "1.0.1"},
-  io.netty/netty-handler {:mvn/version "4.1.82.Final"},
-  org.clj-commons/primitive-math {:mvn/version "1.0.0"},
+  #:mvn{:version "4.1.82.Final"},
+  org.clj-commons/dirigiste #:mvn{:version "1.0.1"},
+  io.netty/netty-handler #:mvn{:version "4.1.82.Final"},
+  org.clj-commons/primitive-math #:mvn{:version "1.0.0"},
   io.netty/netty-transport-native-epoll$linux-x86_64
-  {:mvn/version "4.1.82.Final"},
-  io.netty/netty-transport {:mvn/version "4.1.82.Final"},
-  org.clj-commons/byte-streams {:mvn/version "0.3.1"},
-  io.netty/netty-codec-http {:mvn/version "4.1.82.Final"},
-  potemkin/potemkin {:mvn/version "0.4.5"},
-  io.netty/netty-resolver {:mvn/version "4.1.82.Final"},
-  io.netty/netty-resolver-dns {:mvn/version "4.1.82.Final"}},
+  #:mvn{:version "4.1.82.Final"},
+  io.netty/netty-transport #:mvn{:version "4.1.82.Final"},
+  org.clj-commons/byte-streams #:mvn{:version "0.3.1"},
+  io.netty/netty-codec-http #:mvn{:version "4.1.82.Final"},
+  potemkin/potemkin #:mvn{:version "0.4.5"},
+  io.netty/netty-resolver #:mvn{:version "4.1.82.Final"},
+  io.netty/netty-resolver-dns #:mvn{:version "4.1.82.Final"}},
  :aliases
  {:lein2deps
   {:deps
-   {io.github.borkdude/lein2deps
-    {:git/sha "1bcf2fbbcbef611381e5e9ccdc77bec1e62ea5e5"}},
+   #:io.github.borkdude{lein2deps
+                        #:git{:sha
+                              "1bcf2fbbcbef611381e5e9ccdc77bec1e62ea5e5"}},
    :ns-default lein2deps.build,
    :lein2deps/compile-java
    {:src-dirs ["src/aleph/utils"],


### PR DESCRIPTION
This was prompted by a failing CI job after merging https://github.com/clj-commons/aleph/pull/635 Here, babashka's master branch had changed between the last CI run on the PR and the run after merge. Apparently this included some change in the pretty-printer's behavior, resulting in syntactically different `deps.edn` files. This illustrates why having such moving dependencies isn't great for CI, so we pin it to the current master commit now.

Also included is the resulting changes for the generated `deps.edn`.