### PR TITLE
Support graceful shutdown with ChannelGroup

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -52,8 +52,7 @@
    | `idle-timeout` | when set, connections are closed after not having performed any I/O operations for the given duration, in milliseconds. Defaults to `0` (infinite idle time).
    | `continue-handler` | optional handler which is invoked when header sends \"Except: 100-continue\" header to test whether the request should be accepted or rejected. Handler should return `true`, `false`, ring responseo to be used as a reject response or deferred that yields one of those.
    | `continue-executor` | optional `java.util.concurrent.Executor` which is used to handle requests passed to :continue-handler.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread.
-   | `shutdown-quiet-period` | optional period in seconds for which new connections will still be serviced after a scheduled shutdown via `java.io.Closeable#close`. Defaults to 2 seconds.
-   | `shutdown-timeout` | optional grace period in seconds on which to wait for the event loop group to empty during a scheduled shutdown. Defaults to 15 seconds."
+   | `shutdown-timeout` | optional grace period in seconds on which to wait for the active connections to be terminated."
   [handler options]
   (server/start-server handler options))
 


### PR DESCRIPTION
## Description

This PR is an attempt to address #638 where we noticed that `EventLoopGroup#shutdownGracefully` timeouts are not waiting for active connections but is closing all the `EventExecutor` right away. [1]
It's not an issue on the Netty side but an expected behaviour. [2]

Still, people using a `shutdown-timeout` would expect active connections to be finished before shutting down the server.
The proposition is to track all `Channel` on an `ChannelGroup` [3], and wait for them to be closed before shutting down the server. This use case is mentioned on the `ChannelGroup` Java documentation.

- [x] : Track all Channel on `channel-active` for HTTP and TCP servers
- [x] : Wait the `ChannelGroup` for at most the `shutdown-timeout`
- [x] : Take into account the `elasped` time when calling `EventLoopGroup#shutdownGracefully`
- [x] : Ensure it's backward compatible with public exposed functions
- [x] : Deprecate `shutdown-quiet-period` (which hasn't been released)   
- [x] : Reformat the code

## Open questions

- ~Shall we apply this behavior only when `shutdown-timeout` is explicitly set? And keep the current weird behavior?~
- ~Do we have to be backward compatible with `raw-ring-handler` and `ring-handler`? Having that `when channel-group` is bothering me...~

Let's keep the current behavior when `shutdown-timeout` is not explicitly set.

[1] : https://github.com/netty/netty/blob/4.1/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java#L420
[2] : https://github.com/netty/netty/pull/3706#issuecomment-1303066857
[3] : https://netty.io/4.0/api/io/netty/channel/group/ChannelGroup.html