### PR TITLE
netty: configurable server graceful shutdowns

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -52,8 +52,7 @@
    | `idle-timeout` | when set, connections are closed after not having performed any I/O operations for the given duration, in milliseconds. Defaults to `0` (infinite idle time).
    | `continue-handler` | optional handler which is invoked when header sends \"Except: 100-continue\" header to test whether the request should be accepted or rejected. Handler should return `true`, `false`, ring responseo to be used as a reject response or deferred that yields one of those.
    | `continue-executor` | optional `java.util.concurrent.Executor` which is used to handle requests passed to :continue-handler.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread.
-   | `shutdown-quiet-period` | optional period in seconds for which new connections will still be serviced after a scheduled shutdown via `java.io.Closeable#close`. Defaults to 2 seconds.
-   | `shutdown-timeout` | optional grace period in seconds on which to wait for the event loop group to empty during a scheduled shutdown. Defaults to 15 seconds."
+   | `shutdown-timeout` | interval in seconds within which in-flight requests must be processed, defaults to 15 seconds. A value of 0 bypasses waiting entirely."
   [handler options]
   (server/start-server handler options))
 

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -578,14 +578,12 @@
            compression?
            continue-handler
            continue-executor
-           shutdown-quiet-period
            shutdown-timeout]
     :or {bootstrap-transform identity
          pipeline-transform identity
          shutdown-executor? true
          epoll? false
          compression? false
-         shutdown-quiet-period netty/default-shutdown-quiet-period
          shutdown-timeout netty/default-shutdown-timeout}
     :as options}]
   (let [executor (cond
@@ -642,7 +640,6 @@
                      (when (instance? ExecutorService continue-executor)
                        (.shutdown ^ExecutorService continue-executor))))
       :transport (if epoll? :epoll :nio)
-      :shutdown-quiet-period shutdown-quiet-period
       :shutdown-timeout shutdown-timeout})))
 
 ;;;

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -80,15 +80,13 @@
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it.
    | `pipeline-transform` | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `raw-stream?` | if true, messages from the stream will be `io.netty.buffer.ByteBuf` objects rather than byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
-   | `shutdown-quiet-period` | optional period in seconds for which new connections will still be serviced after a scheduled shutdown via `java.io.Closeable::close`. Defaults to 2 seconds.
-   | `shutdown-timeout` | optional grace period in seconds on which to wait for the event loop group to empty during a scheduled shutdown. Defaults to 15 seconds.  "
+   | `shutdown-timeout` | interval in seconds within which in-flight requests must be processed, defaults to 15 seconds. A value of 0 bypasses waiting entirely."
   [handler
    {:keys [port socket-address ssl-context bootstrap-transform pipeline-transform epoll?
-           shutdown-quiet-period shutdown-timeout]
+           shutdown-timeout]
     :or {bootstrap-transform identity
          pipeline-transform identity
          epoll? false
-         shutdown-quiet-period netty/default-shutdown-quiet-period
          shutdown-timeout netty/default-shutdown-timeout}
     :as options}]
   (netty/start-server
@@ -103,7 +101,6 @@
                       socket-address
                       (InetSocketAddress. port))
     :transport (if epoll? :epoll :nio)
-    :shutdown-quiet-period shutdown-quiet-period
     :shutdown-timeout shutdown-timeout}))
 
 (defn- ^ChannelHandler client-channel-handler

--- a/test/aleph/classloader_test.clj
+++ b/test/aleph/classloader_test.clj
@@ -44,7 +44,7 @@
       (with-dynamic-redefs [netty/operation-complete (partial operation-complete result)]
         (let [server (http/start-server
                       (constantly {:body "ok"})
-                      {:port 9999})]
+                      {:port 9999 :shutdown-timeout 0})]
           (on-signal :int
                      (bound-fn [_] (.close ^java.io.Closeable server)))
           (.exec (Runtime/getRuntime) (format "kill -SIGINT %s" (pid)))

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -163,7 +163,7 @@
    :body body})
 
 (deftest test-send-multipart-request
-  (let [s (http/start-server echo-handler {:port port1})
+  (let [s (http/start-server echo-handler {:port port1 :shutdown-timeout 0})
         ^String resp @(d/chain'
                        (http/post url1 {:multipart parts})
                        :body
@@ -202,6 +202,7 @@
 
 (defn- test-decoder [port url raw-stream?]
   (let [s (http/start-server decode-handler {:port port
+                                             :shutdown-timeout 0
                                              :raw-stream? raw-stream?})
         chunks (-> (http/post url {:multipart parts})
                    (deref 1e3 {:body "timeout"})

--- a/test/aleph/http_continue_test.clj
+++ b/test/aleph/http_continue_test.clj
@@ -36,7 +36,7 @@
 (defn- test-accept [server-options]
   (with-server (http/start-server ok-handler (merge
                                               server-options
-                                              {:port port}))
+                                              {:port port :shutdown-timeout 0}))
     (let [c @(tcp/client {:host "localhost" :port port})]
       @(s/put! c (pack-lines ["PUT /file HTTP/1.1"
                               "Host: localhost"
@@ -69,7 +69,7 @@
   (let [resp (or resp "417 Expectation Failed")]
     (with-server (http/start-server ok-handler (merge
                                                 server-options
-                                                {:port port}))
+                                                {:port port :shutdown-timeout 0}))
       (let [c @(tcp/client {:host "localhost" :port port})]
         @(s/put! c (pack-lines ["PUT /file HTTP/1.1"
                                 "Host: localhost"

--- a/test/aleph/http_timeout_test.clj
+++ b/test/aleph/http_timeout_test.clj
@@ -1,0 +1,97 @@
+(ns aleph.http-timeout-test
+  (:require [aleph.http   :as http]
+            [clj-commons.byte-streams :as bs]
+            [clojure.test :refer [deftest testing is]]
+            [manifold.stream :as s])
+  (:import java.lang.AutoCloseable))
+
+(def ^:private default-options
+  {:throw-exceptions? false
+   :pool (http/connection-pool {:connection-options {:keep-alive? false}})})
+
+(def ^:private port 8082)
+
+(defn- http-get
+  [& {:as options}]
+  (http/get (str "http://localhost:" port) (merge default-options options)))
+
+(defn- streaming-handler
+  [_]
+  (let [body (s/stream)]
+    (future
+      (dotimes [i 10]
+        (s/put! body (str i "."))
+        (Thread/sleep 200))
+      (s/close! body))
+    {:status 200
+     :body body}))
+
+(defn- waiting-handler
+  [_]
+  (Thread/sleep 2000)
+  {:status 200
+   :body   "waited"})
+
+(defn- server-options
+  [& {:as options}]
+  (merge {:port 8082 :shutdown-timeout 4}
+         options))
+
+(deftest test-shutdown-timeout-1
+  (testing "shutdown and wait for streaming in-flight requests to finish."
+    (let [server (http/start-server streaming-handler (server-options))]
+      (try
+        (let [resp (http-get)]
+          (Thread/sleep 50) ;; wait a bit for the request to be initiated
+          (.close ^AutoCloseable server)
+          (is (= 200 (:status @resp)))
+          (is (= "0.1.2.3.4.5.6.7.8.9." (bs/to-string (:body @resp)))))
+        (finally
+          (.close ^AutoCloseable server)))))
+
+  (testing "shutdown and wait for blocking in-flight requests to finish."
+    (let [server (http/start-server waiting-handler (server-options :shutdown-timeout 4))]
+      (try
+        (let [resp (http-get)]
+          (Thread/sleep 50) ;; wait a bit for the request to be initiated
+          (.close ^AutoCloseable server)
+          (is (= 200 (:status @resp)))
+          (is (= "waited" (bs/to-string (:body @resp)))))
+        (finally
+          (.close ^AutoCloseable server))))))
+
+(deftest test-shutdown-timeout-2
+  (testing "shutdown with a timeout of 0 second and no grace for in-flight requests"
+    (let [server (http/start-server waiting-handler (server-options :shutdown-timeout 0))]
+      (try
+        (let [resp (http-get)]
+          (Thread/sleep 50) ;; wait a bit for the request to be initiated
+          (.close ^AutoCloseable server)
+          (is (thrown-with-msg? Exception #"connection was closed after 0\." @resp)))
+        (finally
+          (.close ^AutoCloseable server))))))
+
+(deftest test-shutdown-timeout-3
+  (testing "shutdown with a timeout of 1 seconds with streaming body"
+    (let [server (http/start-server streaming-handler (server-options :shutdown-timeout 1))]
+      (try
+        (let [resp (http-get)]
+          (Thread/sleep 50) ;; wait a bit for the request to be initiated
+          (.close ^AutoCloseable server)
+          (is (= 200 (:status @resp)))
+          (is (= "0.1.2.3.4.5." (bs/to-string (:body @resp)))))
+        (finally
+          (.close ^AutoCloseable server))))))
+
+
+(deftest test-shutdown-timeout-4
+  (testing "shutdown with a timeout of 1 seconds while waiting for body"
+    (let [server (http/start-server waiting-handler (server-options :shutdown-timeout 1))]
+      (try
+        (let [resp (http-get)]
+          (Thread/sleep 50) ;; wait a bit for the request to be initiated
+          (.close ^AutoCloseable server)
+          (is (thrown-with-msg? Exception #"connection was closed after 1\." @resp)))
+        (finally
+          (.close ^AutoCloseable server))))))
+

--- a/test/aleph/ring_test.clj
+++ b/test/aleph/ring_test.clj
@@ -46,7 +46,7 @@
      :body (prn-str (get-request-value request keys))}))
 
 (defmacro with-server [keys & body]
-  `(let [server# (http/start-server (request-callback ~keys) {:port 8080})]
+  `(let [server# (http/start-server (request-callback ~keys) {:port 8080 :shutdown-timeout 0})]
      (try
        ~@body
        (finally

--- a/test/aleph/tcp_ssl_test.clj
+++ b/test/aleph/tcp_ssl_test.clj
@@ -25,6 +25,7 @@
   (let [ssl-session (atom nil)]
     (with-server (tcp/start-server (ssl-echo-handler ssl-session)
                                    {:port 10001
+                                    :shutdown-timeout 0
                                     :ssl-context ssl/server-ssl-context})
       (let [c @(tcp/client {:host "localhost"
                             :port 10001
@@ -39,6 +40,7 @@
   (let [ssl-session (atom nil)]
     (with-server (tcp/start-server (ssl-echo-handler ssl-session)
                                    {:port 10001
+                                    :shutdown-timeout 0
                                     :ssl-context ssl/server-ssl-context-opts})
       (let [c @(tcp/client {:host "localhost"
                             :port 10001
@@ -53,6 +55,7 @@
   (let [ssl-session (atom nil)]
     (with-server (tcp/start-server (ssl-echo-handler ssl-session)
                                    {:port 10001
+                                    :shutdown-timeout 0
                                     :ssl-context ssl/server-ssl-context})
       (let [c @(tcp/client {:host "localhost"
                             :port 10001
@@ -74,6 +77,7 @@
                                                        (.fireChannelInactive ctx)))]
     (with-server (tcp/start-server (ssl-echo-handler ssl-session)
                                    {:port 10001
+                                    :shutdown-timeout 0
                                     :ssl-context ssl/server-ssl-context
                                     :pipeline-transform (fn [p]
                                                           (.addLast p notify-connection-closed))})
@@ -95,6 +99,7 @@
                                                        (.fireChannelActive ctx)))]
     (with-server (tcp/start-server (fn [s _])
                                    {:port 10001
+                                    :shutdown-timeout 0
                                     :ssl-context ssl/server-ssl-context})
       (let [c (tcp/client {:host "localhost"
                            :port 10001

--- a/test/aleph/tcp_test.clj
+++ b/test/aleph/tcp_test.clj
@@ -19,7 +19,7 @@
          (.close ^java.io.Closeable server#)))))
 
 (deftest test-echo
-  (with-server (tcp/start-server echo-handler {:port 10001})
+  (with-server (tcp/start-server echo-handler {:port 10001 :shutdown-timeout 0})
     (let [c @(tcp/client {:host "localhost", :port 10001})]
       (s/put! c "foo")
       (is (= "foo" (bs/to-string @(s/take! c)))))))

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -22,15 +22,15 @@
          (netty/wait-for-close server#)))))
 
 (defmacro with-handler [handler & body]
-  `(with-server (http/start-server ~handler {:port 8080})
+  `(with-server (http/start-server ~handler {:port 8080 :shutdown-timeout 0})
      ~@body))
 
 (defmacro with-raw-handler [handler & body]
-  `(with-server (http/start-server ~handler {:port 8081, :raw-stream? true})
+  `(with-server (http/start-server ~handler {:port 8081, :raw-stream? true :shutdown-timeout 0})
      ~@body))
 
 (defmacro with-compressing-handler [handler & body]
-  `(with-server (http/start-server ~handler {:port 8080, :compression? true})
+  `(with-server (http/start-server ~handler {:port 8080, :compression? true :shutdown-timeout 0})
      ~@body))
 
 (defn connection-handler


### PR DESCRIPTION
The recently closed #641 and previous #639 were both attempting to improve the server shutdown procedure.

The intent of both these PRs is to make it easily viable to provide the classic blue-green deployment mode where:

- Servers stop listening for incoming requests
- In-flight requests are still processed for a configurable grace period
- All resources are then cleaned up

After more digging (my Netty-foo being a bit rusty of late :-)) an approach relying on
Netty's [*ChannelGroup*](https://netty.io/4.1/api/io/netty/channel/group/ChannelGroup.html) functionality seems to be the right mechanism.

Of course, not everyone will want to keep a set of all active connections, including its memory and latency impact.

This revised PR modifies the previous approach in the following way:

- Allow for hooking into the shutdown process by way of the `shutdown-hook` parameter (accepted by `http/start-server`,` `tcp/start-server`, and `netty/start-server`).
- Provide a maximum time interval for `shutdown-hook` to run in, defaulting to 15 seconds
- ~Walk back configurability of `shutdownGracefully` parameters as they do not give a reliable way to control shutdown.~

In addition to this, a few utilities are provided to handle channel groups, as well as a ready made channel handler to populate a channel group, since this will be the most common use of `shutdown-hook`.

If this PR goes through, I am happy to open a subsequent one with updated docs with a walk-through on how to achieve these stop semantics.

(useful disclosure, @arnaudgeiser and I work together so take his approval seal with a grain of salt :smile:)