### PR TITLE
Switch CI test image back to JDK 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/clojure:1.11.1
+      - image: cimg/clojure:1.11.1-openjdk-8.0
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/test/aleph/ssl.clj
+++ b/test/aleph/ssl.clj
@@ -45,6 +45,8 @@
 
 (def server-ssl-context-opts
   {:private-key server-key
+   ;; See https://github.com/clj-commons/aleph/issues/647
+   :protocols ["TLSv1.2" "TLSv1.3"]
    :certificate-chain [server-cert]
    :trust-store [ca-cert]
    :client-auth :optional})

--- a/test/aleph/tcp_ssl_test.clj
+++ b/test/aleph/tcp_ssl_test.clj
@@ -62,6 +62,8 @@
                             :ssl-context (netty/ssl-client-context
                                           ;; Note the intentionally wrong private key here
                                           {:private-key ssl/server-key
+                                           ;; See https://github.com/clj-commons/aleph/issues/647
+                                           :protocols ["TLSv1.3"]
                                            :certificate-chain (into-array X509Certificate [ssl/client-cert])
                                            :trust-store (into-array X509Certificate [ssl/ca-cert])})})]
         (is (nil? @(s/take! c)))


### PR DESCRIPTION
Since JDK 8 is the minimum supported version, we want to run the test suite against this one. This used to be the case before switching to CircleCI's new Clojure Docker image.

Closes #647