### PR TITLE
netty: do not push bindings on operation-complete

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,6 @@
                                    [org.slf4j/slf4j-simple "1.7.30"]
                                    [com.cognitect/transit-clj "1.0.324"]
                                    [spootnik/signal "0.2.4"]
-                                   [me.mourjo/dynamic-redef "0.1.0"]
                                    ;; This is for self-generating certs for testing ONLY:
                                    [org.bouncycastle/bcprov-jdk18on "1.72"]
                                    [org.bouncycastle/bcpkix-jdk18on "1.72"]]

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -250,15 +250,11 @@
     (let [d (d/deferred nil)]
       (if (.isDone f)
         (operation-complete f d)
-        ;; Ensure the same bindings are installed on the Netty thread (vars,
-        ;; classloader) than the thread registering the
-        ;; `operationComplete` callback.
-        (let [bound-operation-complete (bound-fn* operation-complete)]
-          (.addListener f
-                        (reify GenericFutureListener
-                          (operationComplete [_ _]
-                            (ensure-dynamic-classloader)
-                            (bound-operation-complete f d))))))
+        (.addListener f
+                      (reify GenericFutureListener
+                        (operationComplete [_ _]
+                          (ensure-dynamic-classloader)
+                          (operation-complete f d)))))
       d)))
 
 (defn allocate [x]

--- a/test/aleph/classloader_test.clj
+++ b/test/aleph/classloader_test.clj
@@ -3,7 +3,6 @@
    [aleph.http :as http]
    [aleph.netty :as netty]
    [clojure.test :refer [deftest is testing]]
-   [dynamic-redef.core :refer [with-dynamic-redefs]]
    [manifold.deferred :as d]
    [manifold.utils :refer [when-class]]
    [signal.handler :refer [on-signal]])
@@ -41,7 +40,7 @@
 (deftest test-classloader
   (testing "classloader: ensure the class loader is always a DynamicClassLoader"
     (let [result (CompletableFuture.)]
-      (with-dynamic-redefs [netty/operation-complete (partial operation-complete result)]
+      (with-redefs [netty/operation-complete (partial operation-complete result)]
         (let [server (http/start-server
                       (constantly {:body "ok"})
                       {:port 9999 :shutdown-timeout 0})]

--- a/test/aleph/classloader_test.clj
+++ b/test/aleph/classloader_test.clj
@@ -45,6 +45,6 @@
                       (constantly {:body "ok"})
                       {:port 9999 :shutdown-timeout 0})]
           (on-signal :int
-                     (bound-fn [_] (.close ^java.io.Closeable server)))
+                     (fn [_] (.close ^java.io.Closeable server)))
           (.exec (Runtime/getRuntime) (format "kill -SIGINT %s" (pid)))
           (is (= (deref result 10000 ::timeout) true)))))))


### PR DESCRIPTION
## Description

This removes the usage of `bound-fn*` which has been introduced by the following PR. [1]
It was added for safety while there might be no open issue regarding it.
For some workloads, this operation can take up to 40% of CPU.

Here is the reason why we used to push the bindings [2], but I suppose we fixed it by using `ensure-dynamic-classloader` instead.

![image](https://user-images.githubusercontent.com/5036764/210422745-89a08f73-7c71-4e77-a137-4783cf982185.png)

Here is the gist of the discussion we had with @KingMob :

> Oh yeah, because the code runs on netty and signal threads that aren’t started by the Clojure test, so there’s no automatic thread frame propagation, defeating the use of binding under the hood. Well, the usual solution to interop with Java threads is bound-fn , and that works here. Truthfully, we could probably use bound-fn more when handing things off to Netty to run, it’s always safer.
Anyway, this works:

```clojure
(deftest test-classloader
  (testing "classloader: ensure the class loader is always a DynamicClassLoader"
    (let [result (CompletableFuture.)]
      (with-dynamic-redefs [netty/operation-complete (partial operation-complete result)]
        (let [server (http/start-server
                      (constantly {:body "ok"})
                      {:port 9999})]
          (on-signal :int
                     (bound-fn [_]
                       (.close ^java.io.Closeable server)))
          (.exec (Runtime/getRuntime) (format "kill -SIGINT %s" (pid)))
          (is (= (deref result 30000 ::timeout) true)))))))
```

```clojure
(defn wrap-future
  [^Future f]
  (when f
    (if (.isSuccess f)
      (d/success-deferred (.getNow f) nil)
      (let [d (d/deferred nil)
            bound-operation-complete (bound-fn* operation-complete)]
        (.addListener f
          (reify GenericFutureListener
            (operationComplete [_ _]
              (ensure-dynamic-classloader)
              (bound-operation-complete f d))))
        d))))
```

> [9 h 28] The use of bound-fn in the test ensures it inherits the dynamic redef frame, and bound-fn* in wrap-future ensures the listener will work even if .close->wrap-future is called from a signal thread
[> 9 h 29] We shold probably check everywhere we accept user callbacks for netty and wrap them in bound-fn for safety



[1] : https://github.com/clj-commons/aleph/pull/604
[2] : https://github.com/clj-commons/aleph/pull/425