### PR TITLE
multipart: manual cleanup to handle temporary files

### DIFF
--- a/docs/cljdoc.edn
+++ b/docs/cljdoc.edn
@@ -1,4 +1,5 @@
 {:cljdoc.doc/tree [["Read Me" {:file "README.md"}]
-                   ["HTTP" {:file "docs/http.md"}]
+                   ["HTTP" {:file "docs/http.md"}
+                    ["Handling multipart requests" {:file "docs/http/multipart.md"}]]
                    ["TCP" {:file "docs/tcp.md"}]
                    ["UDP" {:file "docs/udp.md"}]]}

--- a/docs/http/multipart.md
+++ b/docs/http/multipart.md
@@ -1,0 +1,83 @@
+# Handling multipart requests
+
+## Defining the handler
+
+Aleph allows you to handle multipart requests through the usage of the `aleph.http.multipart/decode-request`
+function. This function returns a `manifold.stream` of parts having the following
+specification :
+
+```clojure
+(s/def ::part-name         string?)
+(s/def ::content           (s/or :string       string?
+                                 :input-stream (partial instance? java.io.InputStream)))
+(s/def ::name              (s/nilable string?))
+(s/def ::charset           string?)
+(s/def ::mime-type         string?)
+(s/def ::transfer-encoding (s/nilable string?))
+(s/def ::memory?           boolean?)
+(s/def ::file?             boolean?)
+(s/def ::file              (s/nilable (partial instance? java.io.File)))
+(s/def ::size              int?)
+
+(s/def ::part (s/keys
+               :req-un [::part-name
+                        ::content
+                        ::name
+                        ::charset
+                        ::mime-type
+                        ::transfer-encoding
+                        ::memory?
+                        ::file?
+                        ::file
+                        ::size]))
+```
+
+Every file can be stored either on memory or on the filesystem. It depends on the
+`memory-limit` passed to `decode-request` which defaults to 16 KB.
+
+By default, all the resources are automatically cleaned up as soon as the stream is closed.
+It means that all the temporary files created on the filesystem will be removed.
+
+```clojure
+(require '[aleph.http.multipart :as mp])
+(require '[clojure.java.io      :as io])
+(require '[manifold.stream      :as s])
+
+(defn multipart-handler [req]
+  (let [s (mp/decode-request req {:memory-limit (* 16 1024)})]
+    (doseq [part (s/stream->seq s)]
+      (if (:memory? part))
+        (:content part)                           ;; do what you want with the content
+        (io/copy (:file part) (io/file "..."))))) ;; copy the file on another location
+```
+
+## Limitations
+
+As the consumption of the stream does not happen on the same Thread that cleans the
+resources, the files might be removed before you have the time to copy them on
+another location.
+If you want to rely on that convenient mechanism, you need to ensure all the parts
+you want to handle will fit on memory by overriding the default value.
+Depending on your workload, having a value between `8-100` MiB might be affordable.
+
+```clojure
+(mp/decode-request req {:memory-limit (* 16 1024 1024)})
+```
+
+## Manual cleanup
+
+If you cannot afford that much data on memory and you want to rely on temporary files, 
+you will have to disable the automatic clean up of the resources by passing the parameter
+`{:manual-cleanup? true}`.
+Instead of returning a manifold stream, it will return a vector composed
+of a manifold stream and a callback to clean the associated resources.
+
+```clojure
+(defn multipart-handler [req]
+  (let [[s cleanup-fn] (mp/decode-request req {:manual-cleanup? true})]
+    (doseq [part (s/stream->seq s)]
+      (if (:memory? part))
+         (:content part)         ;; do what you want with the content
+         (io/copy (:file part))) ;; copy the file on another location
+    (cleanup-fn)))
+```

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [io.netty/netty-handler-proxy ~netty-version]
                  [io.netty/netty-resolver ~netty-version]
                  [io.netty/netty-resolver-dns ~netty-version]]
-  :profiles {:dev  {:dependencies [[org.clojure/clojure "1.10.3"]
+  :profiles {:dev  {:dependencies [[org.clojure/clojure "1.11.0"]
                                    [criterium "0.4.6"]
                                    [cheshire "5.10.0"]
                                    [org.slf4j/slf4j-simple "1.7.30"]


### PR DESCRIPTION
## Description

This is a followup PR for #596 (which has been closed in favor of this) to propose a less risky and a backwards compatible approach for multipart requests.

Using temporary files storage is broken with the current `release all resources on stream close` mechanism. Fixing it is barely feasible without introducing a breaking change. 
Still, the current mechanism is really convenient: you consume the stream and you are done! It's working perfectly fine as long as you keep all your data on memory. 
__=> Let's keep it that way.__

I propose here to introduce a `manual-cleanup?` flag (a better name can be proposed) which will return a vector composed of a manifold.stream and a `cleanup` function which can be called after the stream has been consumed.

This PR doesn't aim at bringing a file granularity clean up function (which I think is not necessary) as proposed by #596.

And there is also a cljdoc article attached to this PR : https://github.com/clj-commons/aleph/compare/multipart-requests?expand=1#diff-45f6713a5206dde4c1c69d8ddc5242e5ed09e8256ecec0ab80ff911bb8e967c3R1-R82

Closes : #567