### PR TITLE
doc: no-doc on ->Cookie

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -639,6 +639,8 @@
   :path (.path cookie)
   :value (.value cookie))
 
+(alter-meta! #'->Cookie assoc :private true)
+
 (defn ^:no-doc netty-cookie->cookie [^DefaultCookie cookie]
   (->Cookie cookie))
 


### PR DESCRIPTION
I find out how to add `no-doc` on `->Cookie` to not expose it on the documentation.