### PR TITLE
Add charset to text/plain responses

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -111,8 +111,11 @@
            (.printStackTrace e (java.io.PrintWriter. w))
            (str w))})
 
-(let [[server-name server-value connection-name keep-alive-value close-value date-name content-type]
-      (map #(HttpHeaders/newEntity %) ["Server" "Aleph/0.6.0" "Connection" "Keep-Alive" "Close" "Date" "Content-Type"])]
+(let [[server-name connection-name date-name content-type]
+      (map #(HttpHeaders/newEntity %) ["Server" "Connection" "Date" "Content-Type"])
+
+      [server-value keep-alive-value close-value]
+      (map #(HttpHeaders/newEntity %) ["Aleph/0.6.0" "Keep-Alive" "Close"])]
   (defn send-response
     [^ChannelHandlerContext ctx keep-alive? ssl? error-handler rsp]
     (let [[^HttpResponse rsp body]

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -111,8 +111,8 @@
            (.printStackTrace e (java.io.PrintWriter. w))
            (str w))})
 
-(let [[server-name connection-name date-name]
-      (map #(HttpHeaders/newEntity %) ["Server" "Connection" "Date"])
+(let [[server-name connection-name date-name content-type]
+      (map #(HttpHeaders/newEntity %) ["Server" "Connection" "Date" "Content-Type"])
 
       [server-value keep-alive-value close-value]
       (map #(HttpHeaders/newEntity %) ["Aleph/0.6.0" "Keep-Alive" "Close"])]
@@ -135,6 +135,9 @@
 
           (when-not (.contains headers ^CharSequence date-name)
             (.set headers ^CharSequence date-name (date-header-value ctx)))
+
+          (when (= (.get headers ^CharSequence content-type) "text/plain")
+            (.set headers ^CharSequence content-type "text/plain; charset=UTF-8"))
 
           (.set headers ^CharSequence connection-name (if keep-alive? keep-alive-value close-value))
 

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -111,11 +111,8 @@
            (.printStackTrace e (java.io.PrintWriter. w))
            (str w))})
 
-(let [[server-name connection-name date-name content-type]
-      (map #(HttpHeaders/newEntity %) ["Server" "Connection" "Date" "Content-Type"])
-
-      [server-value keep-alive-value close-value]
-      (map #(HttpHeaders/newEntity %) ["Aleph/0.6.0" "Keep-Alive" "Close"])]
+(let [[server-name server-value connection-name keep-alive-value close-value date-name content-type]
+      (map #(HttpHeaders/newEntity %) ["Server" "Aleph/0.6.0" "Connection" "Keep-Alive" "Close" "Date" "Content-Type"])]
   (defn send-response
     [^ChannelHandlerContext ctx keep-alive? ssl? error-handler rsp]
     (let [[^HttpResponse rsp body]

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -38,15 +38,15 @@
 
 (defn http-get
   ([url]
-   (http-get url nil))
+    (http-get url nil))
   ([url options]
-   (http/get url (merge (default-options) {:pool *pool*} options))))
+    (http/get url (merge (default-options) {:pool *pool*} options))))
 
 (defn http-put
   ([url]
-   (http-put url nil))
+    (http-put url nil))
   ([url options]
-   (http/put url (merge (default-options) {:pool *pool*} options))))
+    (http/put url (merge (default-options) {:pool *pool*} options))))
 
 (def port 8082)
 
@@ -757,6 +757,6 @@
                 {:port port
                  :shutdown-timeout 0})
     (let [resp @(http-get (str "http://localhost:" port "/text_plain"))]
-     (is (= "text/plain; charset=UTF-8" (-> resp :headers (get "Content-Type"))))
-     (is (= 200 (:status resp)))
-     (is (= "Hello" (bs/to-string (:body resp)))))))
+      (is (= "text/plain; charset=UTF-8" (-> resp :headers (get "Content-Type"))))
+      (is (= 200 (:status resp)))
+      (is (= "Hello" (bs/to-string (:body resp)))))))


### PR DESCRIPTION
This adds `charset=UTF-8` to every `text/plain` responses.