### PR TITLE
Add support for `max-request-body-size`

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -42,6 +42,7 @@
    | `request-buffer-size`             | the maximum body size, in bytes, which the server will allow to accumulate before invoking the handler, defaults to `16384`.  This does *not* represent the maximum size request the server can handle (which is unbounded), and is only a means of maximizing performance.
    | `raw-stream?`                     | if `true`, bodies of requests will not be buffered at all, and will be represented as Manifold streams of `io.netty.buffer.ByteBuf` objects rather than as an `InputStream`.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
    | `rejected-handler`                | a spillover request-handler which is invoked when the executor's queue is full, and the request cannot be processed.  Defaults to a `503` response.
+   | `max-request-body-size`           | the maximum length of the request body in bytes. Implcitly adds `io.netty.handler.codec.http.HttpObjectAggregator` on the pipeline. Unspecified and thus disabled by default.
    | `max-initial-line-length`         | the maximum characters that can be in the initial line of the request, defaults to `8192`
    | `max-header-size`                 | the maximum characters that can be in a single header entry of a request, defaults to `8192`
    | `max-chunk-size`                  | the maximum characters that can be in a single chunk of a streamed request, defaults to `16384`

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -40,8 +40,8 @@
      DefaultFullHttpResponse
      FullHttpRequest
      HttpContent HttpHeaders HttpUtil
-     HttpContentCompressor
-     HttpRequest HttpResponse
+     HttpContentCompressor HttpObjectAggregator
+     HttpRequest HttpRequestDecoder HttpResponse
      HttpResponseStatus DefaultHttpHeaders
      HttpServerCodec HttpVersion HttpMethod
      LastHttpContent HttpServerExpectContinueHandler
@@ -517,6 +517,7 @@
      rejected-handler
      error-handler
      request-buffer-size
+     max-request-body-size
      max-initial-line-length
      max-header-size
      max-chunk-size
@@ -562,6 +563,8 @@
             validate-headers
             initial-buffer-size
             allow-duplicate-content-lengths))
+        (#(when max-request-body-size
+         (.addLast ^ChannelPipeline %1 "aggregator" (HttpObjectAggregator. max-request-body-size))))
         (.addLast "continue-handler" continue-handler)
         (.addLast "request-handler" ^ChannelHandler handler)
         (#(when (or compression? (some? compression-level))

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -723,24 +723,24 @@
 (deftest test-max-request-body-size
   (testing "max-request-body-size of 0"
     (with-handler-options (constantly {:body "OK"})
-      {:port 10001
+      {:port port
        :max-request-body-size 0}
-      (let [resp @(http-put (str "http://localhost:" 10001)
+      (let [resp @(http-put (str "http://localhost:" port)
                             {:body "hello"})]
         (is (= 413 (:status resp))))))
 
   (testing "max-request-body-size of 1"
     (with-handler-options (constantly {:body "OK"})
-      {:port 10001
+      {:port port
        :max-request-body-size 1}
-      (let [resp @(http-put (str "http://localhost:" 10001)
+      (let [resp @(http-put (str "http://localhost:" port)
                             {:body "hello"})]
         (is (= 413 (:status resp))))))
 
   (testing "max-request-body-size of 6"
     (with-handler-options (constantly {:body "OK"})
-      {:port 10001
+      {:port port
        :max-request-body-size 6}
-      (let [resp @(http-put (str "http://localhost:" 10001)
+      (let [resp @(http-put (str "http://localhost:" port)
                             {:body "hello"})]
         (is (= 200 (:status resp)))))))

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -719,3 +719,28 @@
           (is (= "hello" (bs/to-string (:body rsp))))))
       (catch Exception _
         (is (not (netty/io-uring-available?)))))))
+
+(deftest test-max-request-body-size
+  (testing "max-request-body-size of 0"
+    (with-handler-options (constantly {:body "OK"})
+      {:port 10001
+       :max-request-body-size 0}
+      (let [resp @(http-put (str "http://localhost:" 10001)
+                            {:body "hello"})]
+        (is (= 413 (:status resp))))))
+
+  (testing "max-request-body-size of 1"
+    (with-handler-options (constantly {:body "OK"})
+      {:port 10001
+       :max-request-body-size 1}
+      (let [resp @(http-put (str "http://localhost:" 10001)
+                            {:body "hello"})]
+        (is (= 413 (:status resp))))))
+
+  (testing "max-request-body-size of 6"
+    (with-handler-options (constantly {:body "OK"})
+      {:port 10001
+       :max-request-body-size 6}
+      (let [resp @(http-put (str "http://localhost:" 10001)
+                            {:body "hello"})]
+        (is (= 200 (:status resp)))))))


### PR DESCRIPTION
It adds the support of `max-request-body-size` by leveraging `HttpObjectAggregator` to do so.
This aggregator returns `413 Entity Too Large` when the content sent to the server is too large.

Closes #452