### PR TITLE
Randomize UDP ports

### DIFF
--- a/test/aleph/udp_test.clj
+++ b/test/aleph/udp_test.clj
@@ -3,26 +3,40 @@
    [aleph.netty :as netty]
    [aleph.udp :as udp]
    [clj-commons.byte-streams :as bs]
-   [clojure.test :refer [deftest testing is]]
-   [manifold.stream :as s]))
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [manifold.stream :as s])
+  (:import
+   (java.net ServerSocket)))
 
 (netty/leak-detector-level! :paranoid)
 
+(def ^:dynamic *port* nil)
+
+(defn rand-port []
+  (with-open [socket (ServerSocket. 0)]
+    (.getLocalPort socket)))
+
+(defn random-port-fixture [f]
+  (binding [*port* (rand-port)]
+    (f)))
+
+(use-fixtures :each random-port-fixture)
+
 (deftest test-echo
-  (let [s @(udp/socket {:port 10001})]
-    (s/put! s {:host "localhost", :port 10001, :message "foo"})
+  (let [s @(udp/socket {:port *port*})]
+    (s/put! s {:host "localhost", :port *port*, :message "foo"})
     (is (= "foo"
            (bs/to-string
-             (:message
-              @(s/take! s)))))
+            (:message
+             @(s/take! s)))))
     (s/close! s)))
 
 (deftest test-transport
   (testing "epoll"
     (try
-      (let [s @(udp/socket {:port 10001 :transport :epoll})]
+      (let [s @(udp/socket {:port *port* :transport :epoll})]
         (try
-          (s/put! s {:host "localhost", :port 10001, :message "foo"})
+          (s/put! s {:host "localhost", :port *port*, :message "foo"})
           (is (= "foo"
                  (bs/to-string
                   (:message
@@ -34,9 +48,9 @@
 
   (testing "kqueue"
     (try
-      (let [s @(udp/socket {:port 10001 :transport :kqueue})]
+      (let [s @(udp/socket {:port *port* :transport :kqueue})]
         (try
-          (s/put! s {:host "localhost", :port 10001, :message "foo"})
+          (s/put! s {:host "localhost", :port *port*, :message "foo"})
           (is (= "foo"
                  (bs/to-string
                   (:message
@@ -48,9 +62,9 @@
 
   (testing "io-uring"
     (try
-      (let [s @(udp/socket {:port 10001 :transport :io-uring})]
+      (let [s @(udp/socket {:port *port* :transport :io-uring})]
         (try
-          (s/put! s {:host "localhost", :port 10001, :message "foo"})
+          (s/put! s {:host "localhost", :port *port*, :message "foo"})
           (is (= "foo"
                  (bs/to-string
                   (:message


### PR DESCRIPTION
## Description

Since an `UDP` socket doesn't implement the `AlephServer` protocol, the `port` function is unavailable.
Here is a quick solution to stabilize those tests.