### PR TITLE
Fix backwards-compatibility on transport + doc

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -123,7 +123,7 @@
    | `response-buffer-size`    | the amount of the response, in bytes, that is buffered before the request returns, defaults to `65536`.  This does *not* represent the maximum size response that the client can handle (which is unbounded), and is only a means of maximizing performance.
    | `keep-alive?`             | if `true`, attempts to reuse connections for multiple requests, defaults to `true`.
    | `idle-timeout`            | when set, forces keep-alive connections to be closed after an idle time, in milliseconds.
-   | `transport`               | the transport to use, one of `:nio`, `:epoll`, `:kqueue` or `:io-uring` (defaults to `:nio`)
+   | `transport`               | the transport to use, one of `:nio`, `:epoll`, `:kqueue` or `:io-uring` (defaults to `:nio`).
    | `raw-stream?`             | if `true`, bodies of responses will not be buffered at all, and represented as Manifold streams of `io.netty.buffer.ByteBuf` objects rather than as an `InputStream`.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
    | `max-initial-line-length` | the maximum length of the initial line (e.g. HTTP/1.0 200 OK), defaults to `65536`
    | `max-header-size`         | the maximum characters that can be in a single header entry of a response, defaults to `65536`
@@ -231,7 +231,7 @@
    | `max-frame-payload`   | maximum allowable frame payload length, in bytes, defaults to `65536`.
    | `max-frame-size`      | maximum aggregate message size, in bytes, defaults to `1048576`.
    | `bootstrap-transform` | an optional function that takes an `io.netty.bootstrap.Bootstrap` object and modifies it.
-   | `transport`               | the transport to use, one of `:nio`, `:epoll`, `:kqueue` or `:io-uring` (defaults to `:nio`)
+   | `transport`               | the transport to use, one of `:nio`, `:epoll`, `:kqueue` or `:io-uring` (defaults to `:nio`).
    | `heartbeats`          | optional configuration to send Ping frames to the server periodically (if the connection is idle), configuration keys are `:send-after-idle` (in milliseconds), `:payload` (optional, empty frame by default) and `:timeout` (optional, to close the connection if Pong is not received after specified timeout)."
   ([url]
    (websocket-client url nil))

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -1298,7 +1298,7 @@ initialize an DnsAddressResolverGroup instance.
                    :bootstrap-transform bootstrap-transform
                    :remote-address      remote-address
                    :local-address       local-address
-                   :epoll?              (if epoll? :epoll :nio)
+                   :transport           (if epoll? :epoll :nio)
                    :name-resolver       name-resolver}))
   ([{:keys [pipeline-builder
             ssl-context

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -1305,8 +1305,8 @@ initialize an DnsAddressResolverGroup instance.
             bootstrap-transform
             ^SocketAddress remote-address
             ^SocketAddress local-address
-            name-resolver
-            transport]}]
+            transport
+            name-resolver]}]
    (ensure-transport-available! transport)
    (let [^Class
          channel (transport-channel transport)

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -79,7 +79,7 @@
    | `pipeline-transform`  | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `raw-stream?`         | if true, messages from the stream will be `io.netty.buffer.ByteBuf` objects rather than byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
    | `shutdown-timeout`    | interval in seconds within which in-flight requests must be processed, defaults to 15 seconds. A value of 0 bypasses waiting entirely.
-   | `transport`           | the transport to use, one of `:nio`, `:epoll`, `:kqueue` or `:io-uring` (defaults to `:nio`)"
+   | `transport`           | the transport to use, one of `:nio`, `:epoll`, `:kqueue` or `:io-uring` (defaults to `:nio`)."
   [handler
    {:keys [port socket-address ssl-context bootstrap-transform pipeline-transform epoll?
            shutdown-timeout transport]
@@ -164,7 +164,7 @@
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.Bootstrap` object, which represents the client, and modifies it.
    | `pipeline-transform`  | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `raw-stream?`         | if true, messages from the stream will be `io.netty.buffer.ByteBuf` objects rather than byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
-   | `transport`               | the transport to use, one of `:nio`, `:epoll`, `:kqueue` or `:io-uring` (defaults to `:nio`)"
+   | `transport`           | the transport to use, one of `:nio`, `:epoll`, `:kqueue` or `:io-uring` (defaults to `:nio`)."
   [{:keys [host port remote-address local-address ssl-context ssl? insecure? pipeline-transform bootstrap-transform epoll? transport]
     :or {bootstrap-transform identity
          epoll? false}

--- a/src/aleph/udp.clj
+++ b/src/aleph/udp.clj
@@ -32,7 +32,7 @@
    | `broadcast?`          | if true, all UDP datagrams are broadcast.
    | `bootstrap-transform` | a function which takes the Netty `Bootstrap` object, and makes any desired changes before it's bound to a socket.
    | `raw-stream?`         | if true, the `:message` within each packet will be `io.netty.buffer.ByteBuf` objects rather than byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
-   | `transport`           | the transport to use, one of `:nio`, `:epoll`, `:kqueue` or `:io-uring` (defaults to `:nio`)"
+   | `transport`           | the transport to use, one of `:nio`, `:epoll`, `:kqueue` or `:io-uring` (defaults to `:nio`)."
   [{:keys [socket-address port broadcast? raw-stream? bootstrap-transform epoll? transport]
     :or {epoll? false
          broadcast? false


### PR DESCRIPTION
## Description

When randomly reviewing some parts of the code I discovered that `netty/create-client` (the backwards-compatibility function) is sending the `epoll?` key instead of the `transport` one.
This function is not used (anymore) inside Aleph but there is a low chance that some Aleph users might still use it with some workarounds... who knows.

So it can be called a regression where the worst case scenario is that the client won't even start. But I don't believe everyone will be impacted.

I also added some `dots` on the documentation for conformance and remove some white spaces.