### PR TITLE
Stabilize tests

### DIFF
--- a/test/aleph/ring_test.clj
+++ b/test/aleph/ring_test.clj
@@ -15,7 +15,7 @@
   ([scheme host port path]
     (str scheme "://" host ":" port path)))
 
-(def pool (http/connection-pool {:connection-options {:aleph/keep-alive? false}}))
+(def pool (http/connection-pool {:connection-options {:keep-alive? false}}))
 
 (defn request
   ([& {:as options}]


### PR DESCRIPTION
## Description

Ensure non keep-alived connections are used in `multipart` and `ring` integration tests.