### PR TITLE
Lein2deps update

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -29,7 +29,7 @@
  {:lein2deps
   {:deps
    {io.github.borkdude/lein2deps
-    {:git/sha "1bcf2fbbcbef611381e5e9ccdc77bec1e62ea5e5"}},
+    {:git/tag "v0.1.0" :git/sha "68b23a9"}},
    :ns-default lein2deps.build,
    :lein2deps/compile-java
    {:src-dirs ["src/aleph/utils"],

--- a/deps.edn
+++ b/deps.edn
@@ -29,7 +29,7 @@
  {:lein2deps
   {:deps
    {io.github.borkdude/lein2deps
-    {:git/tag "v0.1.0" :git/sha "68b23a9"}},
+    {:git/sha "1bcf2fbbcbef611381e5e9ccdc77bec1e62ea5e5"}},
    :ns-default lein2deps.build,
    :lein2deps/compile-java
    {:src-dirs ["src/aleph/utils"],

--- a/deps.edn
+++ b/deps.edn
@@ -36,8 +36,4 @@
     :class-dir "target/classes",
     :javac-opts ["-target" "1.8" "-source" "1.8"]}}},
  :deps/prep-lib
- {:ensure "target/classes", :alias :lein2deps, :fn compile-java},
- :mvn/repos
- {"jboss" "https://repository.jboss.org/nexus/content/groups/public/",
-  "sonatype-oss-public"
-  "https://oss.sonatype.org/content/groups/public/"}}
+ {:ensure "target/classes", :alias :lein2deps, :fn compile-java}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,40 +1,43 @@
 ;; DO NOT EDIT MANUALLY - generated from project.clj via deps/lein-to-deps
-{:paths ["src" "target/classes"],
+{:paths ["src" "resources" "target/classes"],
  :deps
  {org.clojure/tools.logging
   {:mvn/version "1.1.0", :exclusions [org.clojure/clojure]},
-  io.netty/netty-transport-native-kqueue$osx-x86_64
-  #:mvn{:version "4.1.87.Final"},
-  io.netty.incubator/netty-incubator-transport-native-io_uring$linux-aarch_64
-  #:mvn{:version "0.0.16.Final"},
-  io.netty/netty-handler-proxy #:mvn{:version "4.1.87.Final"},
-  manifold/manifold #:mvn{:version "0.3.0"},
-  io.netty/netty-codec #:mvn{:version "4.1.87.Final"},
-  io.netty/netty-transport-native-epoll$linux-aarch_64
-  #:mvn{:version "4.1.87.Final"},
-  org.clj-commons/dirigiste #:mvn{:version "1.0.3"},
-  io.netty/netty-handler #:mvn{:version "4.1.87.Final"},
-  org.clj-commons/primitive-math #:mvn{:version "1.0.0"},
+  manifold/manifold {:mvn/version "0.3.0"},
+  org.clj-commons/byte-streams {:mvn/version "0.3.1"},
+  org.clj-commons/dirigiste {:mvn/version "1.0.3"},
+  org.clj-commons/primitive-math {:mvn/version "1.0.0"},
+  potemkin/potemkin {:mvn/version "0.4.5"},
+  io.netty/netty-transport {:mvn/version "4.1.87.Final"},
   io.netty/netty-transport-native-epoll$linux-x86_64
-  #:mvn{:version "4.1.87.Final"},
+  {:mvn/version "4.1.87.Final"},
+  io.netty/netty-transport-native-epoll$linux-aarch_64
+  {:mvn/version "4.1.87.Final"},
+  io.netty/netty-transport-native-kqueue$osx-x86_64
+  {:mvn/version "4.1.87.Final"},
   io.netty.incubator/netty-incubator-transport-native-io_uring$linux-x86_64
-  #:mvn{:version "0.0.16.Final"},
-  io.netty/netty-transport #:mvn{:version "4.1.87.Final"},
-  org.clj-commons/byte-streams #:mvn{:version "0.3.1"},
-  io.netty/netty-codec-http #:mvn{:version "4.1.87.Final"},
-  potemkin/potemkin #:mvn{:version "0.4.5"},
-  io.netty/netty-resolver #:mvn{:version "4.1.87.Final"},
-  io.netty/netty-resolver-dns #:mvn{:version "4.1.87.Final"}},
+  {:mvn/version "0.0.16.Final"},
+  io.netty.incubator/netty-incubator-transport-native-io_uring$linux-aarch_64
+  {:mvn/version "0.0.16.Final"},
+  io.netty/netty-codec {:mvn/version "4.1.87.Final"},
+  io.netty/netty-codec-http {:mvn/version "4.1.87.Final"},
+  io.netty/netty-handler {:mvn/version "4.1.87.Final"},
+  io.netty/netty-handler-proxy {:mvn/version "4.1.87.Final"},
+  io.netty/netty-resolver {:mvn/version "4.1.87.Final"},
+  io.netty/netty-resolver-dns {:mvn/version "4.1.87.Final"}},
  :aliases
  {:lein2deps
   {:deps
-   #:io.github.borkdude{lein2deps
-                        #:git{:sha
-                              "1bcf2fbbcbef611381e5e9ccdc77bec1e62ea5e5"}},
+   {io.github.borkdude/lein2deps
+    {:git/sha "1bcf2fbbcbef611381e5e9ccdc77bec1e62ea5e5"}},
    :ns-default lein2deps.build,
    :lein2deps/compile-java
    {:src-dirs ["src/aleph/utils"],
     :class-dir "target/classes",
     :javac-opts ["-target" "1.8" "-source" "1.8"]}}},
  :deps/prep-lib
- {:ensure "target/classes", :alias :lein2deps, :fn compile-java}}
+ {:ensure "target/classes", :alias :lein2deps, :fn compile-java},
+ :mvn/repos
+ {"jboss" "https://repository.jboss.org/nexus/content/groups/public/",
+  "sonatype-oss-public"
+  "https://oss.sonatype.org/content/groups/public/"}}

--- a/deps/lein-to-deps
+++ b/deps/lein-to-deps
@@ -5,7 +5,7 @@ set -euo pipefail
 cd "$(dirname -- "${BASH_SOURCE[0]}")/.."
 
 echo ";; DO NOT EDIT MANUALLY - generated from project.clj via deps/lein-to-deps" > deps.edn
-bb -Sdeps '{:deps {io.github.borkdude/lein2deps {:git/sha "2297db9f72e594fc1c623c2a4b1e3868611e314b"}}}' \
+bb -Sdeps '{:deps {io.github.borkdude/lein2deps {:git/tag "v0.1.0" :git/sha "68b23a9"}}}' \
    -m lein2deps.api \
    --eval \
    --print >> deps.edn

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,6 @@
 
 (defproject aleph (or (System/getenv "PROJECT_VERSION") "0.6.1")
   :description "A framework for asynchronous communication"
-  :repositories {"jboss" "https://repository.jboss.org/nexus/content/groups/public/"
-                 "sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}
   :url "https://github.com/clj-commons/aleph"
   :license {:name "MIT License"}
   :dependencies [[org.clojure/tools.logging "1.1.0" :exclusions [org.clojure/clojure]]


### PR DESCRIPTION
This change updates the lein2deps script to [`v0.1.0`](https://github.com/borkdude/lein2deps/blob/main/CHANGELOG.md#010).

This update generates the following improvements:

- a more readable output of deps (no namespace maps) and it maintains the order as in the original `project.clj`.

- It now adds `resources`. In this case that means the clj-kondo configs are now also available to people using Aleph as git dep.
- `:mvn/repos` is now being added according to `:repositories` in `project.clj`