### PR TITLE
Fix logging dep conflict

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           command: |
             sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/3d916df4a0c1e00df94100860b8eb5577e59c56a/install)
 
-      - run: lein deps
+      - run: lein with-profile pedantic deps
 
       - save_cache:
           paths:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ target/**
 .java-version
 **/.clj-kondo/.cache
 **/.lsp
+/.eastwood

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,8 @@
  :deps
  {org.clojure/tools.logging
   {:mvn/version "1.2.4", :exclusions [org.clojure/clojure]},
-  manifold/manifold {:mvn/version "0.3.0"},
+  manifold/manifold
+  {:mvn/version "0.3.0", :exclusions [org.clojure/tools.logging]},
   org.clj-commons/byte-streams {:mvn/version "0.3.1"},
   org.clj-commons/dirigiste {:mvn/version "1.0.3"},
   org.clj-commons/primitive-math {:mvn/version "1.0.0"},

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 {:paths ["src" "resources" "target/classes"],
  :deps
  {org.clojure/tools.logging
-  {:mvn/version "1.1.0", :exclusions [org.clojure/clojure]},
+  {:mvn/version "1.2.4", :exclusions [org.clojure/clojure]},
   manifold/manifold {:mvn/version "0.3.0"},
   org.clj-commons/byte-streams {:mvn/version "0.3.1"},
   org.clj-commons/dirigiste {:mvn/version "1.0.3"},

--- a/examples/project.clj
+++ b/examples/project.clj
@@ -3,6 +3,6 @@
                  [gloss "0.2.6"]
                  [metosin/reitit "0.5.18"]
                  [org.clojure/clojure "1.11.1"]
-                 [org.clojure/core.async "0.4.474"]]
+                 [org.clojure/core.async "1.6.673"]]
   :plugins [[lein-marginalia "0.9.1"]
             [lein-cljfmt "0.9.0"]])

--- a/examples/src/aleph/examples/websocket.clj
+++ b/examples/src/aleph/examples/websocket.clj
@@ -110,18 +110,18 @@
 (let [conn1 @(http/websocket-client "ws://localhost:10000/chat")
       conn2 @(http/websocket-client "ws://localhost:10000/chat")]
 
-;; sign our two users in
+  ;; sign our two users in
   (s/put-all! conn1 ["shoes and ships" "Alice"])
   (s/put-all! conn2 ["shoes and ships" "Bob"])
 
   (s/put! conn1 "hello")
 
-  @(s/take! conn1)   ;=> "Alice: hello"
-  @(s/take! conn2)   ;=> "Alice: hello"
+  (println @(s/take! conn1))                                  ;=> "Alice: hello"
+  (println @(s/take! conn2))                                  ;=> "Alice: hello"
 
   (s/put! conn2 "hi!")
 
-  @(s/take! conn1)   ;=> "Bob: hi!"
-  @(s/take! conn2))   ;=> "Bob: hi!"
+  (println @(s/take! conn1))                                  ;=> "Bob: hi!"
+  (println @(s/take! conn2)))                                 ;=> "Bob: hi!"
 
 (.close s)

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :url "https://github.com/clj-commons/aleph"
   :license {:name "MIT License"}
   :dependencies [[org.clojure/tools.logging "1.2.4" :exclusions [org.clojure/clojure]]
-                 [manifold "0.3.0"]
+                 [manifold "0.3.0" :exclusions [org.clojure/tools.logging]]
                  [org.clj-commons/byte-streams "0.3.1"]
                  [org.clj-commons/dirigiste "1.0.3"]
                  [org.clj-commons/primitive-math "1.0.0"]
@@ -34,7 +34,8 @@
                                    [org.bouncycastle/bcpkix-jdk18on "1.72"]]
                     :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"]}
              :lein-to-deps {:source-paths ["deps"]}
-             :test {:jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=off"]}}
+             :test {:jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=off"]}
+             :pedantic {:pedantic? :abort}}
   :codox {:src-dir-uri "https://github.com/ztellman/aleph/tree/master/"
           :src-linenum-anchor-prefix "L"
           :defaults {:doc/format :markdown}
@@ -43,11 +44,7 @@
                     aleph.http
                     aleph.flow]
           :output-dir "doc"}
-  :plugins [[lein-codox "0.10.7"]
-            [lein-jammin "0.1.1"]
-            [lein-marginalia "0.9.1"]
-            [lein-pprint "1.3.2"]
-            [ztellman/lein-cljfmt "0.1.10"]]
+  :plugins [[lein-pprint "1.3.2"]]
   :java-source-paths ["src/aleph/utils"]
   :cljfmt {:indents {#".*" [[:inner 0]]}}
   :test-selectors {:default #(not

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :description "A framework for asynchronous communication"
   :url "https://github.com/clj-commons/aleph"
   :license {:name "MIT License"}
-  :dependencies [[org.clojure/tools.logging "1.1.0" :exclusions [org.clojure/clojure]]
+  :dependencies [[org.clojure/tools.logging "1.2.4" :exclusions [org.clojure/clojure]]
                  [manifold "0.3.0"]
                  [org.clj-commons/byte-streams "0.3.1"]
                  [org.clj-commons/dirigiste "1.0.3"]


### PR DESCRIPTION
Also includes some other minor changes:

- core.async dep updated in examples
- websocket examples takes are printed, to be less confusing at REPL
- .eastwood file now gitignored

Fixes #676 