### PR TITLE
perf: remove assoc

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -206,7 +206,8 @@
    ^Channel ch
    ^AtomicBoolean websocket?
    question-mark-index
-   body]
+   body
+   request-arrived]
   :uri (let [idx (long question-mark-index)]
          (if (neg? idx)
            (.getUri req)
@@ -222,7 +223,8 @@
   :aleph/keep-alive? (HttpUtil/isKeepAlive req)
   :server-name (netty/channel-server-name ch)
   :server-port (netty/channel-server-port ch)
-  :remote-addr (netty/channel-remote-address ch))
+  :remote-addr (netty/channel-remote-address ch)
+  :aleph/request-arrived request-arrived)
 
 (p/def-derived-map NettyResponse [^HttpResponse rsp complete body]
   :status (-> rsp .status .code)
@@ -232,15 +234,12 @@
   :body body)
 
 (defn netty-request->ring-request [^HttpRequest req ssl? ch body]
-  (assoc
-    (->NettyRequest
-      req
-      ssl?
-      ch
-      (AtomicBoolean. false)
-      (-> req .uri (.indexOf (int 63)))
-      body)
-    :aleph/request-arrived (System/nanoTime)))
+  (->NettyRequest req ssl?
+   ch
+   (AtomicBoolean. false)
+   (-> req .uri (.indexOf (int 63)))
+   body
+   (System/nanoTime)))
 
 (defn netty-response->ring-response [rsp complete body]
   (->NettyResponse rsp complete body))


### PR DESCRIPTION
A small optimization to remove an `assoc` and thus increase the throughput of Aleph a tiny bit.

Context: Updating TechEmpower benchmarks : https://github.com/TechEmpower/FrameworkBenchmarks/pull/7972

__Before__

```
❯ wrk -t2 -c16 -d10s http://127.0.0.1:8081
Running 10s test @ http://127.0.0.1:8081
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    90.29us  209.16us  15.77ms   99.59%
    Req/Sec    72.61k     3.23k   79.40k    57.43%
  1458703 requests in 10.10s, 239.27MB read
Requests/sec: 144430.27
Transfer/sec:     23.69MB
❯ wrk -t2 -c16 -d10s http://127.0.0.1:8081
Running 10s test @ http://127.0.0.1:8081
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    86.75us  129.66us  10.24ms   99.55%
    Req/Sec    74.54k     1.77k   90.19k    86.57%
  1490845 requests in 10.10s, 244.55MB read
Requests/sec: 147619.41
Transfer/sec:     24.21MB
❯ wrk -t2 -c16 -d10s http://127.0.0.1:8081
Running 10s test @ http://127.0.0.1:8081
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   115.80us  352.83us  15.21ms   98.39%
    Req/Sec    74.70k     3.07k   85.61k    73.27%
  1500496 requests in 10.10s, 246.13MB read
Requests/sec: 148568.02
Transfer/sec:     24.37MB
```

__After__

```
❯ wrk -t2 -c16 -d10s http://127.0.0.1:8081
Running 10s test @ http://127.0.0.1:8081
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    93.66us  260.78us  20.98ms   99.51%
    Req/Sec    74.88k     2.72k   83.96k    75.50%
  1490282 requests in 10.00s, 244.45MB read
Requests/sec: 149026.19
Transfer/sec:     24.45MB
❯ wrk -t2 -c16 -d10s http://127.0.0.1:8081
Running 10s test @ http://127.0.0.1:8081
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    87.96us  154.74us  18.56ms   99.52%
    Req/Sec    75.19k     1.91k   79.56k    67.33%
  1511275 requests in 10.10s, 247.90MB read
Requests/sec: 149636.74
Transfer/sec:     24.55MB
❯ wrk -t2 -c16 -d10s http://127.0.0.1:8081
Running 10s test @ http://127.0.0.1:8081
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   119.65us  611.65us  23.17ms   99.35%
    Req/Sec    73.43k     5.10k   83.19k    81.68%
  1475016 requests in 10.10s, 241.95MB read
Requests/sec: 146043.85
Transfer/sec:     23.96MB
```
