### PR TITLE
Do not remove Expect header from the request

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -486,7 +486,6 @@ Example: {:status 200
                                        ^ByteBufHolder
                                        default-accept-response)]
                          (netty/write-and-flush ctx rsp)
-                         (.remove (.headers req) HttpHeaderNames/EXPECT)
                          (.fireChannelRead ctx req))
                        ;; rejected, use the default reject response if
                        ;; alternative is not provided


### PR DESCRIPTION
## Description

I don't get exactly what was the rationale about removing it from the request, but we have a use case where we need to have access to this to take a decision. [1]
My proposition is to keep it on the request.

[1] : https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.1