### PR TITLE
Run all HTTP SSL tests against both HTTP versions, too

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -242,6 +242,7 @@
   :server-name (netty/channel-server-name ch)
   :server-port (netty/channel-server-port ch)
   :remote-addr (netty/channel-remote-address ch)
+  :aleph/channel ch
   :aleph/request-arrived request-arrived
   :protocol "HTTP/1.1")
 
@@ -267,8 +268,8 @@
   [rsp destroy-conn? body]
   (->NettyResponse rsp destroy-conn? body))
 
-(defn ring-request-ssl-session [^NettyRequest req]
-  (netty/channel-ssl-session (.ch req)))
+(defn ring-request-ssl-session [req]
+  (netty/channel-ssl-session (:aleph/channel req)))
 
 ;;;
 

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -238,14 +238,14 @@
   :request-method (-> req .method .name str/lower-case keyword)
   :body body
   :scheme (if ssl? :https :http)
-  :aleph/keep-alive? (HttpUtil/isKeepAlive req)
   :server-name (netty/channel-server-name ch)
   :server-port (netty/channel-server-port ch)
   :remote-addr (netty/channel-remote-address ch)
   :protocol "HTTP/1.1"
-  ;; These keys are internal to Aleph and should not be relied on
-  :aleph/channel ch
-  :aleph/request-arrived request-arrived)
+  :aleph/keep-alive? (HttpUtil/isKeepAlive req)
+  :aleph/request-arrived request-arrived
+  ;; The following keys are internal to Aleph and should not be relied on
+  :aleph/channel ch)
 
 (p/def-derived-map NettyResponse [^HttpResponse rsp destroy-conn? body]
   :status (-> rsp .status .code)

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -242,9 +242,10 @@
   :server-name (netty/channel-server-name ch)
   :server-port (netty/channel-server-port ch)
   :remote-addr (netty/channel-remote-address ch)
+  :protocol "HTTP/1.1"
+  ;; These keys are internal to Aleph and should not be relied on
   :aleph/channel ch
-  :aleph/request-arrived request-arrived
-  :protocol "HTTP/1.1")
+  :aleph/request-arrived request-arrived)
 
 (p/def-derived-map NettyResponse [^HttpResponse rsp destroy-conn? body]
   :status (-> rsp .status .code)

--- a/src/aleph/http/http2.clj
+++ b/src/aleph/http/http2.clj
@@ -822,12 +822,13 @@
 
      :protocol              "HTTP/2.0"
 
-     ;; These keys are internal to Aleph and should not be relied on
+     :aleph/keep-alive?     true                            ; not applicable to HTTP/2, but here for compatibility
+     :aleph/request-arrived (System/nanoTime)
+
+     ;; The following keys are internal to Aleph and should not be relied on
      :aleph/channel         ch
      :aleph/writable?       writable?
-     :aleph/h2-exception    h2-exception
-     :aleph/keep-alive?     true                            ; not applicable to HTTP/2, but here for compatibility
-     :aleph/request-arrived (System/nanoTime)}))
+     :aleph/h2-exception    h2-exception}))
 
 (defn- validate-netty-req-headers
   "Netty is not currently checking for missing pseudo-headers, so we do it here."

--- a/src/aleph/http/http2.clj
+++ b/src/aleph/http/http2.clj
@@ -822,6 +822,7 @@
 
      :protocol              "HTTP/2.0"
 
+     ;; These keys are internal to Aleph and should not be relied on
      :aleph/channel         ch
      :aleph/writable?       writable?
      :aleph/h2-exception    h2-exception

--- a/src/aleph/http/http2.clj
+++ b/src/aleph/http/http2.clj
@@ -822,6 +822,7 @@
 
      :protocol              "HTTP/2.0"
 
+     :aleph/channel         ch
      :aleph/writable?       writable?
      :aleph/h2-exception    h2-exception
      :aleph/keep-alive?     true                            ; not applicable to HTTP/2, but here for compatibility

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -1190,11 +1190,12 @@
   (partial coerce-ssl-context ssl-client-context))
 
 (defn ^:no-doc channel-ssl-session [^Channel ch]
-  (some-> ch
-          ^ChannelPipeline (.pipeline)
-          ^SslHandler (.get SslHandler)
-          .engine
-          .getSession))
+  (or (some-> ch
+              ^ChannelPipeline (.pipeline)
+              ^SslHandler (.get SslHandler)
+              .engine
+              .getSession)
+      (recur (.parent ch))))
 
 (defn ^:no-doc ssl-handshake-error? [^Throwable ex]
   (and (instance? DecoderException ex)

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -1190,13 +1190,14 @@
   (partial coerce-ssl-context ssl-client-context))
 
 (defn ^:no-doc channel-ssl-session [^Channel ch]
-  (or (some-> ch
-              ^ChannelPipeline (.pipeline)
-              ^SslHandler (.get SslHandler)
-              .engine
-              .getSession)
-      ;; Needed for multiplexed child channels (e.g. as present in HTTP/2)
-      (recur (.parent ch))))
+  (when ch
+    (or (some-> ch
+                ^ChannelPipeline (.pipeline)
+                ^SslHandler (.get SslHandler)
+                .engine
+                .getSession)
+        ;; Needed for multiplexed child channels (e.g. as present in HTTP/2)
+        (recur (.parent ch)))))
 
 (defn ^:no-doc ssl-handshake-error? [^Throwable ex]
   (and (instance? DecoderException ex)

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -1195,6 +1195,7 @@
               ^SslHandler (.get SslHandler)
               .engine
               .getSession)
+      ;; Needed for multiplexed child channels (e.g. as present in HTTP/2)
       (recur (.parent ch))))
 
 (defn ^:no-doc ssl-handshake-error? [^Throwable ex]


### PR DESCRIPTION
To that end, introduce a new `with-http-ssl-servers` macro which works like `with-http-servers` but with SSL enabled for both versions. It also sets `*use-tls* true` by default.

This also fixes some tests which were passing `http1-ssl-server-options` to `with-http-servers`. This resulted in them running only against HTTP/1 (twice) because the `:ssl-context` of `with-http2-server` would get overridden.

With this change, `test-ssl-session-access` is failing in the HTTP/2 case. This is because it calls `http.core/ring-request-ssl-session` on the ring request. However, this fails because the HTTP/2 server implementation currently doesn't wrap the ring request in `aleph.http.core/NettyRequest`. @KingMob Can we just change it to do that or is there a good reason for not doing so?

Note: To avoid conflicts, this PR is based on https://github.com/clj-commons/aleph/pull/698