### PR TITLE
Set up ALPN configuration based on http-versions when possible

### DIFF
--- a/examples/src/aleph/examples/http2.clj
+++ b/examples/src/aleph/examples/http2.clj
@@ -45,6 +45,7 @@
 
 (def s (http/start-server hello-world-handler
                           {:port        443
+                           :http-versions [:http2 :http1]
                            :ssl-context http2-ssl-ctx}))
 
 ;; ## Clients
@@ -79,6 +80,7 @@
 ;; server
 (def s (http/start-server hello-world-handler
                           {:port         443
+                           :http-versions [:http2 :http1]
                            :ssl-context  http2-ssl-ctx
                            :compression? true}))
 

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -15,6 +15,8 @@
     [manifold.deferred :as d]
     [manifold.executor :as executor])
   (:import
+    (aleph.http.core
+      HeaderMap)
     (aleph.utils
       ConnectionTimeoutException
       PoolTimeoutException
@@ -500,7 +502,7 @@
 (defn get-all
   "Given a header map from an HTTP request or response, returns a collection of
    values associated with the key, rather than a comma-delimited string."
-  [header-m ^String k]
+  [^HeaderMap header-m ^String k]
   (let [raw-headers (.headers header-m)]
     (condp instance? raw-headers
       HttpHeaders (.getAll ^HttpHeaders raw-headers k)

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -35,16 +35,20 @@
 
    Defaults to HTTP/1.1-only.
 
-   To enable HTTP/2, you must supply an SslContext with ALPN support for HTTP/2.
-   See `aleph.netty/ssl-server-context` and `aleph.netty/application-protocol-config`
-   for more details. (You can also set `use-h2c?` to force HTTP/2 cleartext, but
-   this is strongly discouraged.)
+   To enable HTTP/2, add `:http2` to the `http-versions` option. This requires you to also enable
+   SSL via the `ssl-context` option. If you supply an `io.netty.handler.ssl.SslContext` instance, you
+   have to set it up with ALPN support for HTTP/2.  See `aleph.netty/ssl-server-context` and
+   `aleph.netty/application-protocol-config` for more details. If you supply an SSL options map
+   without an `:application-protocol-config` key instead, the necessary ALPN configuration will be
+   set up automatically. (You can also set `use-h2c?` to force HTTP/2 cleartext, but this is strongly
+   discouraged.)
 
    | Param key                         | Description |
    | ---                               | --- |
    | `port`                            | The port the server will bind to. If `0`, the server will bind to a random port. |
    | `socket-address`                  | A `java.net.SocketAddress` specifying both the port and interface to bind to. |
    | `bootstrap-transform`             | A function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it. |
+   | `http-versions`                   | An optional vector of allowable HTTP versions to negotiate via ALPN, in preference order. Defaults to `[:http1]`. |
    | `ssl-context`                     | An `io.netty.handler.ssl.SslContext` object or a map of SSL context options (see `aleph.netty/ssl-server-context` for more details) if an SSL connection is desired |
    | `manual-ssl?`                     | Set to `true` to indicate that SSL is active, but the caller is managing it (this implies `:ssl-context` is nil). For example, this can be used if you want to use configure SNI (perhaps in `:pipeline-transform` ) to select the SSL context based on the client's indicated host name. |
    | `executor`                        | A `java.util.concurrent.Executor` which is used to handle individual requests. To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread. |

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -14,6 +14,8 @@
     [manifold.stream :as s]
     [potemkin :as p])
   (:import
+    (aleph.http.core
+      HeaderMap)
     (io.netty.buffer
       ByteBuf
       Unpooled)
@@ -746,7 +748,7 @@
 (defn ^:no-doc extract-cookies-from-response-headers
   ([headers]
    (extract-cookies-from-response-headers default-cookie-spec headers))
-  ([cookie-spec header-m]
+  ([cookie-spec ^HeaderMap header-m]
    (let [raw-headers (.headers header-m)]
      (->> (condp instance? raw-headers
             HttpHeaders (.getAll ^HttpHeaders raw-headers set-cookie-header-name)

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -729,6 +729,7 @@
    {:keys [port
            socket-address
            executor
+           http-versions
            ssl-context
            manual-ssl?
            shutdown-executor?
@@ -742,7 +743,9 @@
            epoll?                          false
            shutdown-timeout                netty/default-shutdown-timeout}
     :as   opts}]
-  (let [^SslContext ssl-context (netty/coerce-ssl-server-context ssl-context)
+  (let [^SslContext ssl-context (-> ssl-context
+                                    (common/ensure-consistent-alpn-config http-versions)
+                                    (netty/coerce-ssl-server-context))
         opts (assoc opts :ssl-context ssl-context)
         http1-pipeline-transform (common/validate-http1-pipeline-transform opts)
         executor (setup-executor executor)

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -633,7 +633,7 @@
 
 (defn make-pipeline-builder
   "Returns a function that initializes a new server channel's pipeline."
-  [handler {:keys [ssl? ssl-context use-h2c?] :as opts}]
+  [handler {:keys [ssl? ^SslContext ssl-context use-h2c?] :as opts}]
   (fn pipeline-builder*
     [^ChannelPipeline pipeline]
     (log/trace "pipeline-builder*" pipeline opts)

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -900,6 +900,10 @@
     :openssl SslProvider/OPENSSL
     :openssl-refcnt SslProvider/OPENSSL_REFCNT))
 
+(def key->application-protocol-name
+  {:http1 ApplicationProtocolNames/HTTP_1_1
+   :http2 ApplicationProtocolNames/HTTP_2})
+
 (let [cert-array-class (class (into-array X509Certificate []))]
   (defn- add-ssl-trust-manager! ^SslContextBuilder [^SslContextBuilder builder trust-store]
     (cond (instance? File trust-store)

--- a/test/aleph/ssl.clj
+++ b/test/aleph/ssl.clj
@@ -2,12 +2,6 @@
   (:require
     [aleph.netty :as netty])
   (:import
-    (io.netty.handler.ssl
-      ApplicationProtocolConfig
-      ApplicationProtocolConfig$Protocol
-      ApplicationProtocolConfig$SelectedListenerFailureBehavior
-      ApplicationProtocolConfig$SelectorFailureBehavior
-      ApplicationProtocolNames)
     (io.netty.handler.ssl.util SelfSignedCertificate)
     (java.io ByteArrayInputStream)
     (java.security KeyFactory PrivateKey)
@@ -56,36 +50,15 @@
    :protocols                   ["TLSv1.2" "TLSv1.3"]
    :certificate-chain           [server-cert]
    :trust-store                 [ca-cert]
-   :client-auth                 :optional
-   :application-protocol-config (netty/application-protocol-config
-                                  [ApplicationProtocolNames/HTTP_1_1 ApplicationProtocolNames/HTTP_2])})
+   :client-auth                 :optional})
 
 (def server-ssl-context
   (netty/ssl-server-context server-ssl-context-opts))
 
-(def http1-only-ssl-context
-  (netty/ssl-server-context (assoc server-ssl-context-opts
-                                   :application-protocol-config
-                                   (netty/application-protocol-config [:http1]))))
-
-(def http2-only-ssl-context
-  "Well, minus the HTTP/1 fallback if ALPN isn't being used at all..."
-  (netty/ssl-server-context (assoc server-ssl-context-opts
-                                   :application-protocol-config
-                                   (netty/application-protocol-config [:http2]))))
-
 (def client-ssl-context-opts
   {:private-key                 client-key
    :certificate-chain           [client-cert]
-   :trust-store                 [ca-cert]
-   :application-protocol-config (ApplicationProtocolConfig.
-                                  ApplicationProtocolConfig$Protocol/ALPN
-                                  ;; NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.
-                                  ApplicationProtocolConfig$SelectorFailureBehavior/NO_ADVERTISE
-                                  ;; ACCEPT is currently the only mode supported by both OpenSsl and JDK providers.
-                                  ApplicationProtocolConfig$SelectedListenerFailureBehavior/ACCEPT
-                                  ^"[Ljava.lang.String;"
-                                  (into-array String [ApplicationProtocolNames/HTTP_1_1 ApplicationProtocolNames/HTTP_2]))})
+   :trust-store                 [ca-cert]})
 
 (def client-ssl-context
   (netty/ssl-client-context client-ssl-context-opts))


### PR DESCRIPTION
This also adds an `http-versions` option to `aleph.http/start-server`. Its value will be used to
automatically set up a matching ALPN config when `ssl-context` is a map and doesn't contain a
`:application-protocol-config` key, yet. Support for the latter is retained so that users can still
override the default in case any more interesting settings will become available in the future.

If an `:application-protocol-config` is present, we assert that the configured protocols match the
desired HTTP versions. We need to have that validation code path anyway for the case when an
`io.netty.handler.ssl.SslContext` instance is passed, which made the decision to retain the
`:application-protocol-config` option easier.

Closes #696.

Some review notes:

* Is it too strict to not allow more HTTP versions to be present in a custom ALPN config than specified via `:http-versions`? At first I thought so but then it would allow silly things like `:http-versions []` or might lead to accidental misconfiguration.
* I added a test case which starts a server for `:http2` without an `ssl-context`. I expected it to fail to start the server but it currently succeeds. Should we make this an error?
* Another test case enabled `use-h2c?`  but also passes an `ssl-context` in which case the latter wins. Should this be an error?