### PR TITLE
Add more reliable resource leak detector for tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -57,17 +57,24 @@
                                                   "-Dorg.slf4j.simpleLogger.log.io.netty.util=error"
                                                   "-Dorg.slf4j.simpleLogger.log.io.netty.channel=warn"]}
              :test                {:jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=off"]}
-             :leak-level-paranoid {:jvm-opts ["-Dio.netty.leakDetectionLevel=PARANOID"]}
+             :leak-detection {:aot [aleph.resource-leak-detector]
+                              :jvm-opts ["-Dio.netty.leakDetection.level=PARANOID"
+                                         "-Dio.netty.customResourceLeakDetector=aleph.resource_leak_detector"
+                                         "-Dorg.slf4j.simpleLogger.log.aleph.resource-leak-detector=info"
+                                         ;; These settings empirically make leak detection more reliable
+                                         "-Dio.netty.leakDetection.targetRecords=1"
+                                         "-Dio.netty.allocator.type=unpooled"]}
              :pedantic            {:pedantic? :abort}
              :trace               {:jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=trace"]}
              :profile             {:dependencies [[com.clojure-goes-fast/clj-async-profiler "1.1.1"]]
                                    :jvm-opts     ["-Djdk.attach.allowAttachSelf"]}}
   :java-source-paths ["src-java"]
   :test-selectors {:default   #(not
-                                 (some #{:benchmark :stress}
+                                 (some #{:benchmark :stress :leak}
                                    (cons (:tag %) (keys %))))
                    :benchmark :benchmark
                    :stress    :stress
+                   :leak      :leak ; requires :leak-detection profile
                    :all       (constantly true)}
   :jvm-opts ^:replace ["-server"
                        "-Xmx2g"

--- a/test/aleph/http_continue_test.clj
+++ b/test/aleph/http_continue_test.clj
@@ -3,6 +3,7 @@
    [aleph.flow :as flow]
    [aleph.http :as http]
    [aleph.netty :as netty]
+   [aleph.resource-leak-detector]
    [aleph.tcp :as tcp]
    [clj-commons.byte-streams :as bs]
    [clojure.string :as str]
@@ -105,3 +106,5 @@
     (test-reject {:continue-handler
                   (constantly (d/success-deferred {:status 401}))}
                  "401 Unauthorized")))
+
+(aleph.resource-leak-detector/instrument-tests!)

--- a/test/aleph/http_timeout_test.clj
+++ b/test/aleph/http_timeout_test.clj
@@ -1,5 +1,6 @@
 (ns aleph.http-timeout-test
   (:require [aleph.http :as http]
+            [aleph.resource-leak-detector]
             [clj-commons.byte-streams :as bs]
             [clojure.test :refer [deftest testing is]]
             [manifold.stream :as s])
@@ -95,3 +96,4 @@
         (finally
           (.close ^AutoCloseable server))))))
 
+(aleph.resource-leak-detector/instrument-tests!)

--- a/test/aleph/netty_test.clj
+++ b/test/aleph/netty_test.clj
@@ -1,6 +1,7 @@
 (ns aleph.netty-test
   (:require
    [aleph.netty :as netty]
+   [aleph.resource-leak-detector]
    [clojure.test :refer [deftest is]]
    [manifold.stream :as s])
   (:import
@@ -52,3 +53,5 @@
     (is (-> config .isAutoRead))
     (netty/put! channel s 6)
     (is (not (-> config .isAutoRead)))))
+
+(aleph.resource-leak-detector/instrument-tests!)

--- a/test/aleph/resource_leak_detector.clj
+++ b/test/aleph/resource_leak_detector.clj
@@ -1,0 +1,210 @@
+(ns aleph.resource-leak-detector
+  "Provides a Netty leak detector which is more reliable than the default implementation.
+
+  Its chance of detecting leaks is around 95%. See `with-leak-collection` for details.
+
+  Since it adds considerable runtime overhead, its main purpose is to be used in tests to assert
+  intentional presence of leaks and to check for unintended leaks. The main API entry points for
+  this are `with-leak-collection`, `with-expected-leaks` and `instrument-tests!`.
+
+  To enable it, pass `-Dio.netty.customResourceLeakDetector=aleph.resource_leak_detector` to the
+  JVM. You will also have to pass `-Dio.netty.leakDetection.level=PARANOID`.
+
+  Most reliable results are achieved by also passing the following options:
+  `-Dio.netty.leakDetection.targetRecords=1`
+  `-Dio.netty.allocator.type=unpooled`
+
+  All of the above is also provided by the `:leak-detection` Leiningen profile.
+
+  NOTE: Currently only improves reliability for detecting leaked ByteBufs. Other types of leaked
+  resources will still be detected but not with the same reliability. Search Netty's codebase for
+  invocations of `newResourceLeakDetector` to see which other candidate resources types there are."
+  (:gen-class
+   :extends io.netty.util.ResourceLeakDetector)
+  (:require
+   [clojure.test :as test]
+   [clojure.tools.logging :as log])
+  (:import
+   (io.netty.buffer AbstractByteBufAllocator)
+   (io.netty.util
+    ResourceLeakDetector
+    ResourceLeakDetector$Level
+    ResourceLeakDetectorFactory)))
+
+(defn enabled?
+  "Checks whether the resource leak detector is enabled.
+
+  See `aleph.resource-leak-detector` docstring on how to enable it."
+  []
+  (= "aleph.resource_leak_detector"
+     (System/getProperty "io.netty.customResourceLeakDetector")))
+
+(def active-resource-leak-detector-class
+  (delay
+    (class (.newResourceLeakDetector (ResourceLeakDetectorFactory/instance) String))))
+
+(def active?
+  (delay
+    (= (Class/forName "aleph.resource_leak_detector")
+       @active-resource-leak-detector-class)))
+
+(defn ensure-consistent-config! []
+  (when-not @active?
+    (if (enabled?)
+      (throw (RuntimeException.
+              (str "`aleph.resource_leak_detector` is enabled but the active resource leak detector is "
+                   "`" (.getName ^Class @active-resource-leak-detector-class)"`. This indicates that "
+                   "`io.netty.util.ResourceLeakDetectorFactory` ran into an initialization error. "
+                   "Enable Netty debug logging to diagnose the cause.")))
+      (throw (RuntimeException.
+              (str "Attempted to use `aleph.resource-leak-detector` API but it is not enabled. "
+                   "Pass `-Dio.netty.customResourceLeakDetector=aleph.resource_leak_detector` to enable.")))))
+  (when-not (= ResourceLeakDetector$Level/PARANOID (ResourceLeakDetector/getLevel))
+    (throw (RuntimeException.
+            (str "`aleph.resource_leak_detector` requires `-Dio.netty.leakDetection.level=PARANOID`. "
+                 "Current level is `" (ResourceLeakDetector/getLevel) "`.")))))
+
+(def +max-probe-gc-runs+
+  "Maximum number of times the GC will be run to detect a leaked probe."
+  10)
+
+(def +probe-hint-marker+
+  "ALEPH LEAK DETECTOR PROBE")
+
+(defn hint-record-pattern [hint-pattern]
+  (re-pattern (str "(?m)^\\s*Hint: " hint-pattern "$")))
+
+(def +probe-hint-pattern+
+  (hint-record-pattern (str +probe-hint-marker+ " \\d+")))
+
+(defn probe? [leak]
+  (re-find +probe-hint-pattern+ (:records leak)))
+
+(defn contains-hint? [hint leak]
+  (re-find (hint-record-pattern hint) (:records leak)))
+
+(defn remove-probes [leaks]
+  (remove probe? leaks))
+
+(let [cnt (atom 0)]
+  (defn gen-probe-hint []
+    (str +probe-hint-marker+ " " (swap! cnt inc))))
+
+(defn leak-probe! [hint]
+  (-> AbstractByteBufAllocator/DEFAULT
+      (.buffer 1)
+      (.touch hint)))
+
+(def current-leaks)
+
+(defn force-leak-detection! []
+  (System/gc)
+  (System/runFinalization)
+  ;; Transitively trigger a track() invocation which in turn works
+  ;; off the leaked references queue.
+  (-> AbstractByteBufAllocator/DEFAULT (.buffer 1) .release))
+
+(defn await-probe! [probe-hint]
+  (loop [n +max-probe-gc-runs+]
+    (force-leak-detection!)
+    (if (zero? n)
+      (throw (RuntimeException. "Gave up awaiting leak probe. Try increasing +max-probe-gc-runs+."))
+      (when-not (some (partial contains-hint? probe-hint) @current-leaks)
+        (recur (dec n))))))
+
+(defn with-leak-collection
+  "Invokes thunk `f` and tries hard to collect any resource leaks it may have caused.
+
+  It works as follows: After invoking `f`, it intentionally leaks a (small) buffer, marked as a
+  probe. It then runs the garbage collector and polls the leak detector in a loop until it reports a
+  leak which matches the probe. Eventually, it invokes `handle-leaks` with a sequence of any other
+  detected leaks it collected along the way (empty when none were detected).
+
+  A leak is represented as a map with the following keys:
+  - `:resource-type` is a string with the name of the leaked resource type (e.g. \"ByteBuf\")
+  - `:records` is a multi-line string which holds the trace of the leak.
+
+  Requires the leak detector to be `enabled?`.
+
+  When nested, each child establishes a fresh leak collection scope. However, this only works within
+  the same thread, so any asynchronous processes started by and outliving `f` will leak into the
+  parent scope(s)."
+  [f handle-leaks]
+  (ensure-consistent-config!)
+  (with-redefs [current-leaks (atom [])]
+    (f)
+    (let [hint (gen-probe-hint)]
+      (leak-probe! hint)
+      (await-probe! hint)
+      (handle-leaks (remove-probes @current-leaks)))))
+
+(defn -needReport [_this]
+  true)
+
+(defn -reportTracedLeak [_this resource-type records]
+  (swap! current-leaks conj {:resource-type resource-type
+                             :records records}))
+
+;; NOTE: Since we require level PARANOID, this should never be called in practice.
+(defn -reportUntracedLeak [_this resource-type]
+  (swap! current-leaks conj {:resource-type resource-type
+                             :records "[untraced]"}))
+
+(defn log-leaks! [leaks]
+  (doseq [{:keys [resource-type records]} leaks]
+    ;; Log message cribbed from io.netty.util.ResourceLeakDetector's (protected) reportTracedLeak method
+    (log/error (str "LEAK: " resource-type ".release() was not called before it's garbage-collected.")
+               (str "See https://netty.io/wiki/reference-counted-objects.html for more information." records))))
+
+(defmacro with-expected-leaks
+  "Runs `body` and expects it to produce exactly `expected-leak-count` leaks. Intended for use in tests
+  which intentionally leak resources.
+
+  Requires the leak detector to be `enabled?`."
+  [expected-leak-count & body]
+  `(with-leak-collection
+     (fn [] ~@body)
+     ;; NOTE: Using a raw symbol here instead of a gensym to get nicer test failures.
+     (fn [~'leaks]
+       (when-not (test/is (= ~expected-leak-count (count ~'leaks)) "Unexpected leak count! See log output for details.")
+         (log-leaks! ~'leaks)))))
+
+(defn- report-test-leaks! [leaks]
+  (when (seq leaks)
+    (log-leaks! leaks)
+    ;; We include the assertion here within the `when` form so that we don't add a mystery assertion
+    ;; to every passing test (which is the common case).
+    (test/is (zero? (count leaks))
+             "Leak detected! See log output for details.")))
+
+(defn- instrument-test-fn [tf]
+  (if (::instrumented? tf)
+    tf
+    (with-meta
+      (fn []
+        (with-leak-collection tf report-test-leaks!))
+      {::instrumented? true})))
+
+(defn instrument-tests!
+  "If `enabled?`, instruments all tests in the current namespace with leak detection by wrapping them
+  in `with-leak-collection`. If leaks are detected, a corresponding (failing) assertion is injected
+  into the test and the leak reports are logged at level `error`.
+
+  Usually placed at the end of a test namespace.
+
+  Note that this is intentionally not implemented as a fixture since there is no clean way to make a
+  test fail from within a fixture: Neither a failing assertion nor throwing an exception will
+  preserve which particular test caused it. See
+  e.g. https://github.com/technomancy/leiningen/issues/2694 for an example of this."
+  []
+  (when (enabled?)
+    (->> (ns-interns *ns*)
+         vals
+         (filter (comp :test meta))
+         (run! (fn [tv]
+                 (alter-meta! tv update :test instrument-test-fn))))))
+
+(if (enabled?)
+  (log/info "enabled.")
+  (log/info "disabled. This means resource leaks will be reported less accurately."
+            "Pass `-Dio.netty.customResourceLeakDetector=aleph.resource_leak_detector` to enable."))

--- a/test/aleph/resource_leak_detector.clj
+++ b/test/aleph/resource_leak_detector.clj
@@ -57,21 +57,21 @@
             (str "`aleph.resource_leak_detector` requires `-Dio.netty.leakDetection.level=PARANOID`. "
                  "Current level is `" (ResourceLeakDetector/getLevel) "`.")))))
 
-(def +max-probe-gc-runs+
+(def max-probe-gc-runs
   "Maximum number of times the GC will be run to detect a leaked probe."
   10)
 
-(def +probe-hint-marker+
+(def probe-hint-marker
   "ALEPH LEAK DETECTOR PROBE")
 
 (defn hint-record-pattern [hint-pattern]
   (re-pattern (str "(?m)^\\s*Hint: " hint-pattern "$")))
 
-(def +probe-hint-pattern+
-  (hint-record-pattern (str +probe-hint-marker+ " \\d+")))
+(def probe-hint-pattern
+  (hint-record-pattern (str probe-hint-marker " \\d+")))
 
 (defn probe? [leak]
-  (re-find +probe-hint-pattern+ (:records leak)))
+  (re-find probe-hint-pattern (:records leak)))
 
 (defn contains-hint? [hint leak]
   (re-find (hint-record-pattern hint) (:records leak)))
@@ -81,7 +81,7 @@
 
 (let [cnt (atom 0)]
   (defn gen-probe-hint []
-    (str +probe-hint-marker+ " " (swap! cnt inc))))
+    (str probe-hint-marker " " (swap! cnt inc))))
 
 (defn leak-probe! [hint]
   (-> AbstractByteBufAllocator/DEFAULT
@@ -98,10 +98,10 @@
   (-> AbstractByteBufAllocator/DEFAULT (.buffer 1) .release))
 
 (defn await-probe! [probe-hint]
-  (loop [n +max-probe-gc-runs+]
+  (loop [n max-probe-gc-runs]
     (force-leak-detection!)
     (if (zero? n)
-      (throw (RuntimeException. "Gave up awaiting leak probe. Try increasing +max-probe-gc-runs+."))
+      (throw (RuntimeException. "Gave up awaiting leak probe. Try increasing `aleph.resource-leak-detector/max-probe-gc-runs`."))
       (when-not (some (partial contains-hint? probe-hint) @current-leaks)
         (recur (dec n))))))
 

--- a/test/aleph/resource_leak_detector.clj
+++ b/test/aleph/resource_leak_detector.clj
@@ -7,14 +7,7 @@
   intentional presence of leaks and to check for unintended leaks. The main API entry points for
   this are `with-leak-collection`, `with-expected-leaks` and `instrument-tests!`.
 
-  To enable it, pass `-Dio.netty.customResourceLeakDetector=aleph.resource_leak_detector` to the
-  JVM. You will also have to pass `-Dio.netty.leakDetection.level=PARANOID`.
-
-  Most reliable results are achieved by also passing the following options:
-  `-Dio.netty.leakDetection.targetRecords=1`
-  `-Dio.netty.allocator.type=unpooled`
-
-  All of the above is also provided by the `:leak-detection` Leiningen profile.
+  To enable it, use the `:leak-detection` Leiningen profile.
 
   NOTE: Currently only improves reliability for detecting leaked ByteBufs. Other types of leaked
   resources will still be detected but not with the same reliability. Search Netty's codebase for
@@ -58,7 +51,7 @@
                    "Enable Netty debug logging to diagnose the cause.")))
       (throw (RuntimeException.
               (str "Attempted to use `aleph.resource-leak-detector` API but it is not enabled. "
-                   "Pass `-Dio.netty.customResourceLeakDetector=aleph.resource_leak_detector` to enable.")))))
+                   "To enable it, use the `:leak-detection` Leiningen profile.")))))
   (when-not (= ResourceLeakDetector$Level/PARANOID (ResourceLeakDetector/getLevel))
     (throw (RuntimeException.
             (str "`aleph.resource_leak_detector` requires `-Dio.netty.leakDetection.level=PARANOID`. "
@@ -205,6 +198,6 @@
                  (alter-meta! tv update :test instrument-test-fn))))))
 
 (if (enabled?)
-  (log/info "enabled.")
-  (log/info "disabled. This means resource leaks will be reported less accurately."
-            "Pass `-Dio.netty.customResourceLeakDetector=aleph.resource_leak_detector` to enable."))
+  (log/info "aleph.resource-leak-detector enabled.")
+  (log/info "aleph.resource-leak-detector disabled. This means resource leaks will be reported less accurately."
+            "To enable it, use the `:leak-detection` Leiningen profile."))

--- a/test/aleph/ring_test.clj
+++ b/test/aleph/ring_test.clj
@@ -2,10 +2,9 @@
   (:require
    [aleph.http :as http]
    [aleph.netty :as netty]
+   [aleph.resource-leak-detector]
    [clj-commons.byte-streams :as bs]
    [clojure.test :refer [deftest is]]))
-
-(netty/leak-detector-level! :paranoid)
 
 (defn create-url
   ([path]
@@ -92,3 +91,5 @@
 (deftest test-host-header
   (with-server [:headers :host]
     (is (= "localhost:8080" (request)))))
+
+(aleph.resource-leak-detector/instrument-tests!)

--- a/test/aleph/tcp_ssl_test.clj
+++ b/test/aleph/tcp_ssl_test.clj
@@ -1,6 +1,7 @@
 (ns aleph.tcp-ssl-test
   (:require
     [aleph.netty :as netty]
+    [aleph.resource-leak-detector]
     [aleph.ssl :as ssl]
     [aleph.tcp :as tcp]
     [aleph.tcp-test :refer [with-server]]
@@ -12,8 +13,6 @@
     (java.security.cert X509Certificate)
     (java.util.concurrent TimeoutException)
     (javax.net.ssl SSLHandshakeException)))
-
-(netty/leak-detector-level! :paranoid)
 
 (set! *warn-on-reflection* false)
 
@@ -148,3 +147,5 @@
         (is (not (d/realized? c)))
         (deliver continue-handshake true)
         (is (deref c 1000 false))))))
+
+(aleph.resource-leak-detector/instrument-tests!)

--- a/test/aleph/tcp_test.clj
+++ b/test/aleph/tcp_test.clj
@@ -1,12 +1,11 @@
 (ns aleph.tcp-test
   (:require
    [aleph.netty :as netty]
+   [aleph.resource-leak-detector]
    [aleph.tcp :as tcp]
    [clj-commons.byte-streams :as bs]
    [clojure.test :refer [deftest testing is]]
    [manifold.stream :as s]))
-
-(netty/leak-detector-level! :paranoid)
 
 (defn echo-handler [s _]
   (s/connect s s))
@@ -55,3 +54,5 @@
             (is (= "foo" (bs/to-string @(s/take! c)))))))
       (catch Exception _
         (is (not (netty/io-uring-available?)))))))
+
+(aleph.resource-leak-detector/instrument-tests!)

--- a/test/aleph/udp_test.clj
+++ b/test/aleph/udp_test.clj
@@ -2,13 +2,12 @@
   (:require
    [aleph.netty :as netty]
    [aleph.udp :as udp]
+   [aleph.resource-leak-detector]
    [clj-commons.byte-streams :as bs]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [manifold.stream :as s])
   (:import
    (java.net ServerSocket)))
-
-(netty/leak-detector-level! :paranoid)
 
 (def ^:dynamic *port* nil)
 
@@ -73,3 +72,5 @@
             (s/close! s))))
       (catch Exception _
         (is (not (netty/io-uring-available?)))))))
+
+(aleph.resource-leak-detector/instrument-tests!)

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -4,14 +4,13 @@
    [aleph.http.websocket.common :as ws.common]
    [aleph.http.websocket.server :as ws.server]
    [aleph.netty :as netty]
+   [aleph.resource-leak-detector]
    [clj-commons.byte-streams :as bs]
    [clojure.test :refer [deftest is testing]]
    [clojure.tools.logging :as log]
    [manifold.deferred :as d]
    [manifold.stream :as s]
    [manifold.time :as time]))
-
-(netty/leak-detector-level! :paranoid)
 
 (defmacro with-server [server & body]
   `(let [server# ~server]
@@ -325,3 +324,5 @@
              (is (= "hello" @(s/try-take! c 5e3)))))
          (catch Exception _
            (is (not (netty/io-uring-available?)))))))
+
+(aleph.resource-leak-detector/instrument-tests!)


### PR DESCRIPTION
See docstrings in `aleph.resource-leak-detector` for details.

This patch also includes the following changes:

* Rename the `:leak-level-paranoid` Leiningen profile to `:leak-detection` since it now also sets everything up to use the new custom detector.
* Introduce new test selector `:leak` for tests which intentionally leak (not run by default since they require the `:leak-detection` profile to be active, too).
* Introduce intentionally leaking `aleph.http-test/test-leak-in-raw-stream-handler` as an example and to document a case where users are responsible for releasing buffers.
* Eliminate all `(netty/leak-detector-level! :paranoid)` calls from tests. Use new leak detection API instead (see below).
* Place `(aleph.resource-leak-detector/instrument-tests!)` at the end of all relevant test namespaces to detect leaks (only effective when running with `:leak-detection` profile).

Ideally we'd activate it in the CI test job but we first need to fix the leak in `aleph.http-test/test-idle-timeout` for that (see #707).

Based on the research results from  #615.