### PR TITLE
Drop fixed HTTP server shutdown timeout

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -1729,9 +1729,7 @@
                    (d/finally'
                      ;; 3. At this stage, stop the EventLoopGroup, this will cancel any
                      ;;    in flight pending requests.
-                     ;;    We still wait 1.5s to gracefully end repeating tasks
-                     ;;    like the date-header-value.
-                     #(.shutdownGracefully group 1500 1500 TimeUnit/MILLISECONDS)))
+                     #(.shutdownGracefully group 0 0 TimeUnit/MILLISECONDS)))
                (when on-close
                  (d/chain'
                    (wrap-future (.terminationFuture group))


### PR DESCRIPTION
This is a WIP artifact from the patch which introduced HTTP/2 support. It is no longer needed and dropping it reduces test suite runtime from roughly 5 minutes to roughly 40 seconds.

See https://github.com/clj-commons/aleph/pull/687#discussion_r1402354975 for discussion.