### PR TITLE
Bump timeouts for DNS failure tests

### DIFF
--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -1184,7 +1184,7 @@
   (testing "unknown host with JDK DNS resolver"
     (is (thrown? UnknownHostException
                  (-> (http/get "http://unknown-host/")
-                     (d/timeout! 1e3)
+                     (d/timeout! 1e4)
                      deref))))
 
   (testing "unknown host with custom DNS client"
@@ -1194,7 +1194,7 @@
       (try
         (is (thrown? UnknownHostException
                      (-> (http/get "http://unknown-host/" {:pool pool})
-                         (d/timeout! 1e3)
+                         (d/timeout! 1e4)
                          deref)))
         (finally
           (.shutdown ^Pool pool))))))


### PR DESCRIPTION
These started to flake on CI recently with the shorter timeouts.

See e.g. the [failing job on latest `master`](https://app.circleci.com/pipelines/github/clj-commons/aleph/626/workflows/21fc9753-d895-4e64-9180-d826629cdf30/jobs/606).