### PR TITLE
HTTP client request cancellation

### DIFF
--- a/src-java/aleph/utils/RequestCancellationException.java
+++ b/src-java/aleph/utils/RequestCancellationException.java
@@ -1,0 +1,23 @@
+package aleph.utils;
+
+import java.util.concurrent.CancellationException;
+
+public class RequestCancellationException extends CancellationException {
+
+    public RequestCancellationException() { }
+
+    public RequestCancellationException(String message) {
+        super(message);
+    }
+
+    public RequestCancellationException(Throwable cause) {
+        super(cause.getMessage());
+        initCause(cause);
+    }
+
+    public RequestCancellationException(String message, Throwable cause) {
+        super(message);
+        initCause(cause);
+    }
+
+}

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -397,14 +397,7 @@
                                         ;; connection timeout triggered
                                         (d/catch' TimeoutException
                                                   (fn [^Throwable e]
-                                                    (log/error e "Timed out waiting for connection to be established")
                                                     (d/error-deferred (ConnectionTimeoutException. e))))
-
-                                        ;; connection failed, bail out
-                                        (d/catch'
-                                         (fn [e]
-                                           (log/error e "Connection failure")
-                                           (d/error-deferred e)))
 
                                         ;; actually make the request now
                                         (d/chain'

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -453,11 +453,13 @@
       result)))
 
 (defn cancel-request!
-  "Accepts a response deferred as returned by `request` and cancels the underlying request if it is
-  still in flight.
+  "Accepts a response deferred as returned by `request` and closes the underlying TCP connection. If
+  the request had already completed by the time this function is invoked, it has no effect (as per
+  Manifold deferred semantics). If cancellation succeeded, the deferred will be put into error state
+  with an `aleph.utils.RequestCancellationException` instance.
 
-  This is done by putting the deferred into error state with an
-  `aleph.utils.RequestCancellationException` instance as its value."
+  Note that the request may already have been (partially) processed by the server at the point of
+  cancellation."
   [r]
   (d/error! r (RequestCancellationException. "Request cancelled")))
 


### PR DESCRIPTION
This patch changes `aleph.http/request` so that setting the response deferred to an error status will terminate an in-flight request. This allows e.g. for `d/timeout!` to be used without potentially leaking connections.

For convenient explicit cancellation, we provide `aleph.http/cancel-request!`. It puts the given response deferred into error state with an instance of the new `aleph.utils.RequestCancellationException`.

Closes #712.

Review notes:
* ~The patch uses the approach outlined in https://github.com/clj-commons/manifold/issues/167#issuecomment-457996116 for propagating cancellation.~  (not quite, it was merely an inspiration)
* Diff best viewed [without whitespace changes](https://github.com/clj-commons/aleph/pull/714/files?w=1).
* ~Still marked as draft because the patch only pertains to in-flight requests. Connection establishment is not yet cancellable. Combined with the default `connection-timeout` of 60s, this can make for an unpleasant surprise :grimacing:~ -- deferred to a follow-up patch once Netty has responded.