### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,49 +1,49 @@
 ;; DO NOT EDIT MANUALLY - generated from project.clj via deps/lein-to-deps
 {:paths ["src" "resources" "target/classes"],
  :deps
- {org.clojure/clojure {:mvn/version "1.11.1"},
+ {org.clojure/clojure {:mvn/version "1.11.2"},
   org.clojure/tools.logging
-  {:mvn/version "1.2.4", :exclusions [org.clojure/clojure]},
+  {:mvn/version "1.3.0", :exclusions [org.clojure/clojure]},
   manifold/manifold
   {:mvn/version "0.4.2", :exclusions [org.clojure/tools.logging]},
   org.clj-commons/byte-streams {:mvn/version "0.3.4"},
   org.clj-commons/dirigiste {:mvn/version "1.0.4"},
   org.clj-commons/primitive-math {:mvn/version "1.0.1"},
-  potemkin/potemkin {:mvn/version "0.4.6"},
-  io.netty/netty-transport {:mvn/version "4.1.100.Final"},
+  potemkin/potemkin {:mvn/version "0.4.7"},
+  io.netty/netty-transport {:mvn/version "4.1.108.Final"},
   io.netty/netty-transport-native-epoll$linux-x86_64
-  {:mvn/version "4.1.100.Final"},
+  {:mvn/version "4.1.108.Final"},
   io.netty/netty-transport-native-epoll$linux-aarch_64
-  {:mvn/version "4.1.100.Final"},
+  {:mvn/version "4.1.108.Final"},
   io.netty/netty-transport-native-kqueue$osx-x86_64
-  {:mvn/version "4.1.100.Final"},
+  {:mvn/version "4.1.108.Final"},
   io.netty.incubator/netty-incubator-transport-native-io_uring$linux-x86_64
-  {:mvn/version "0.0.18.Final"},
+  {:mvn/version "0.0.25.Final"},
   io.netty.incubator/netty-incubator-transport-native-io_uring$linux-aarch_64
-  {:mvn/version "0.0.18.Final"},
-  io.netty/netty-codec {:mvn/version "4.1.100.Final"},
-  io.netty/netty-codec-http {:mvn/version "4.1.100.Final"},
-  io.netty/netty-codec-http2 {:mvn/version "4.1.100.Final"},
-  io.netty/netty-handler {:mvn/version "4.1.100.Final"},
-  io.netty/netty-handler-proxy {:mvn/version "4.1.100.Final"},
-  io.netty/netty-resolver {:mvn/version "4.1.100.Final"},
-  io.netty/netty-resolver-dns {:mvn/version "4.1.100.Final"},
+  {:mvn/version "0.0.25.Final"},
+  io.netty/netty-codec {:mvn/version "4.1.108.Final"},
+  io.netty/netty-codec-http {:mvn/version "4.1.108.Final"},
+  io.netty/netty-codec-http2 {:mvn/version "4.1.108.Final"},
+  io.netty/netty-handler {:mvn/version "4.1.108.Final"},
+  io.netty/netty-handler-proxy {:mvn/version "4.1.108.Final"},
+  io.netty/netty-resolver {:mvn/version "4.1.108.Final"},
+  io.netty/netty-resolver-dns {:mvn/version "4.1.108.Final"},
   metosin/malli
-  {:mvn/version "0.10.4", :exclusions [org.clojure/clojure]},
-  com.aayushatharva.brotli4j/brotli4j {:mvn/version "1.12.0"},
-  com.aayushatharva.brotli4j/service {:mvn/version "1.12.0"},
+  {:mvn/version "0.15.0", :exclusions [org.clojure/clojure]},
+  com.aayushatharva.brotli4j/brotli4j {:mvn/version "1.16.0"},
+  com.aayushatharva.brotli4j/service {:mvn/version "1.16.0"},
   com.aayushatharva.brotli4j/native-linux-aarch64
-  {:mvn/version "1.12.0"},
+  {:mvn/version "1.16.0"},
   com.aayushatharva.brotli4j/native-linux-armv7
-  {:mvn/version "1.12.0"},
+  {:mvn/version "1.16.0"},
   com.aayushatharva.brotli4j/native-linux-x86_64
-  {:mvn/version "1.12.0"},
+  {:mvn/version "1.16.0"},
   com.aayushatharva.brotli4j/native-osx-aarch64
-  {:mvn/version "1.12.0"},
-  com.aayushatharva.brotli4j/native-osx-x86_64 {:mvn/version "1.12.0"},
+  {:mvn/version "1.16.0"},
+  com.aayushatharva.brotli4j/native-osx-x86_64 {:mvn/version "1.16.0"},
   com.aayushatharva.brotli4j/native-windows-x86_64
-  {:mvn/version "1.12.0"},
-  com.github.luben/zstd-jni {:mvn/version "1.5.5-7"}},
+  {:mvn/version "1.16.0"},
+  com.github.luben/zstd-jni {:mvn/version "1.5.6-2"}},
  :aliases
  {:lein2deps
   {:deps

--- a/project.clj
+++ b/project.clj
@@ -1,25 +1,25 @@
 ;; you'll need to run the script at `deps/lein-to-deps` after changing any dependencies
-(def netty-version "4.1.100.Final")
-(def brotli-version "1.12.0")
+(def netty-version "4.1.108.Final")
+(def brotli-version "1.16.0")
 
 
 (defproject aleph (or (System/getenv "PROJECT_VERSION") "0.7.1")
   :description "A framework for asynchronous communication"
   :url "https://github.com/clj-commons/aleph"
   :license {:name "MIT License"}
-  :dependencies [[org.clojure/clojure "1.11.1"]
-                 [org.clojure/tools.logging "1.2.4" :exclusions [org.clojure/clojure]]
+  :dependencies [[org.clojure/clojure "1.11.2"]
+                 [org.clojure/tools.logging "1.3.0" :exclusions [org.clojure/clojure]]
                  [manifold "0.4.2" :exclusions [org.clojure/tools.logging]]
                  [org.clj-commons/byte-streams "0.3.4"]
                  [org.clj-commons/dirigiste "1.0.4"]
                  [org.clj-commons/primitive-math "1.0.1"]
-                 [potemkin "0.4.6"]
+                 [potemkin "0.4.7"]
                  [io.netty/netty-transport ~netty-version]
                  [io.netty/netty-transport-native-epoll ~netty-version :classifier "linux-x86_64"]
                  [io.netty/netty-transport-native-epoll ~netty-version :classifier "linux-aarch_64"]
                  [io.netty/netty-transport-native-kqueue ~netty-version :classifier "osx-x86_64"]
-                 [io.netty.incubator/netty-incubator-transport-native-io_uring "0.0.18.Final" :classifier "linux-x86_64"]
-                 [io.netty.incubator/netty-incubator-transport-native-io_uring "0.0.18.Final" :classifier "linux-aarch_64"]
+                 [io.netty.incubator/netty-incubator-transport-native-io_uring "0.0.25.Final" :classifier "linux-x86_64"]
+                 [io.netty.incubator/netty-incubator-transport-native-io_uring "0.0.25.Final" :classifier "linux-aarch_64"]
                  [io.netty/netty-codec ~netty-version]
                  [io.netty/netty-codec-http ~netty-version]
                  [io.netty/netty-codec-http2 ~netty-version]
@@ -27,7 +27,7 @@
                  [io.netty/netty-handler-proxy ~netty-version]
                  [io.netty/netty-resolver ~netty-version]
                  [io.netty/netty-resolver-dns ~netty-version]
-                 [metosin/malli "0.10.4" :exclusions [org.clojure/clojure]]
+                 [metosin/malli "0.15.0" :exclusions [org.clojure/clojure]]
                  ;;[com.aayushatharva.brotli4j/all ~brotli-version]
                  [com.aayushatharva.brotli4j/brotli4j ~brotli-version]
                  [com.aayushatharva.brotli4j/service ~brotli-version]
@@ -37,17 +37,17 @@
                  [com.aayushatharva.brotli4j/native-osx-aarch64 ~brotli-version]
                  [com.aayushatharva.brotli4j/native-osx-x86_64 ~brotli-version]
                  [com.aayushatharva.brotli4j/native-windows-x86_64 ~brotli-version]
-                 [com.github.luben/zstd-jni "1.5.5-7"]]
+                 [com.github.luben/zstd-jni "1.5.6-2"]]
   :profiles {:dev                 {:dependencies [[criterium "0.4.6"]
-                                                  [cheshire "5.10.0"]
-                                                  [org.slf4j/slf4j-simple "1.7.30"]
-                                                  [com.cognitect/transit-clj "1.0.324"]
-                                                  [spootnik/signal "0.2.4"]
+                                                  [cheshire "5.13.0"]
+                                                  [org.slf4j/slf4j-simple "2.0.12"]
+                                                  [com.cognitect/transit-clj "1.0.333"]
+                                                  [spootnik/signal "0.2.5"]
                                                   ;; This is for dev and testing ONLY, not recommended for prod
-                                                  [org.bouncycastle/bcprov-jdk18on "1.75"]
-                                                  [org.bouncycastle/bcpkix-jdk18on "1.75"]
+                                                  [org.bouncycastle/bcprov-jdk18on "1.77"]
+                                                  [org.bouncycastle/bcpkix-jdk18on "1.77"]
                                                   ;;[org.bouncycastle/bctls-jdk18on "1.75"]
-                                                  [io.netty/netty-tcnative-boringssl-static "2.0.61.Final"]]
+                                                  [io.netty/netty-tcnative-boringssl-static "2.0.65.Final"]]
                                    :jvm-opts     ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
                                                   "-Dorg.slf4j.simpleLogger.showThreadName=false"
                                                   "-Dorg.slf4j.simpleLogger.showThreadId=true"
@@ -66,7 +66,7 @@
                                          "-Dio.netty.allocator.type=unpooled"]}
              :pedantic            {:pedantic? :abort}
              :trace               {:jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=trace"]}
-             :profile             {:dependencies [[com.clojure-goes-fast/clj-async-profiler "1.1.1"]]
+             :profile             {:dependencies [[com.clojure-goes-fast/clj-async-profiler "1.2.0"]]
                                    :jvm-opts     ["-Djdk.attach.allowAttachSelf"]}}
   :java-source-paths ["src-java"]
   :test-selectors {:default   #(not

--- a/test/aleph/ssl.clj
+++ b/test/aleph/ssl.clj
@@ -7,14 +7,14 @@
     (java.security KeyFactory PrivateKey)
     (java.security.cert CertificateFactory X509Certificate)
     (java.security.spec RSAPrivateCrtKeySpec)
-    (org.apache.commons.codec.binary Base64)))
+    (java.util Base64)))
 
 (set! *warn-on-reflection* false)
 
 (defn gen-cert
   ^X509Certificate [^String pemstr]
   (.generateCertificate (CertificateFactory/getInstance "X.509")
-                        (ByteArrayInputStream. (Base64/decodeBase64 pemstr))))
+                        (ByteArrayInputStream. (.decode (Base64/getDecoder) pemstr))))
 
 (defn gen-key
   ^PrivateKey [public-exponent k]


### PR DESCRIPTION
Most importantly, update Netty to 4.1.108.Final which includes the fix for https://github.com/netty/netty/issues/13849 as well as various other fixes, particularly HTTP/2 related ones.