### PR TITLE
Demote insecure/cleartext HTTP pipeline warn log

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -671,12 +671,12 @@
 
             use-h2c?
             (do
-              (log/warn "Setting up cleartext HTTP/2 server pipeline.")
+              (log/debug "Setting up cleartext HTTP/2 server pipeline.")
               (http2/setup-conn-pipeline setup-opts))
 
             :else
             (do
-              (log/info "Setting up insecure HTTP/1 server pipeline.")
+              (log/debug "Setting up insecure HTTP/1 server pipeline.")
               (setup-http1-pipeline setup-opts))))))
 
 ;;;


### PR DESCRIPTION
In the common scenario of a plain HTTP server sitting behind a TLS terminating proxy, these warnings would show up for every newly established connection. In any case, warning the user about a setting they deliberately chose on every connection is a rather annoying default, so demote to `debug`.