### PR TITLE
Fix buffer leak in `test-idle-timeout`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,6 @@ jobs:
       - run: deps/ensure-deps-up-to-date
 
       # run tests!
-      - run: lein do clean, test
+      - run: lein do clean, with-profile +leak-detection test
     # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
     resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,6 @@ jobs:
       - run: deps/ensure-deps-up-to-date
 
       # run tests!
-      - run: lein do clean, with-profile +leak-detection test
+      - run: lein do clean, with-profile +leak-detection test :default+leak
     # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
     resource_class: large

--- a/project.clj
+++ b/project.clj
@@ -75,6 +75,9 @@
                    :benchmark :benchmark
                    :stress    :stress
                    :leak      :leak ; requires :leak-detection profile
+                   :default+leak #(not
+                                   (some #{:benchmark :stress}
+                                         (cons (:tag %) (keys %))))
                    :all       (constantly true)}
   :jvm-opts ^:replace ["-server"
                        "-Xmx2g"

--- a/src/aleph/http/http2.clj
+++ b/src/aleph/http/http2.clj
@@ -1074,16 +1074,17 @@
                      (log/debug "Stream is no longer writable"))))))
 
          (instance? Http2DataFrame msg)
-         (let [content (.content ^Http2DataFrame msg)]
+         (let [content (.content ^Http2DataFrame msg)
+               content-empty? (p/== (.readableBytes content) 0)]
            ;; skip empty bytebufs
-           (when (p/> (.readableBytes content) 0)
+           (when-not content-empty?
              (netty/put! (.channel ctx)
                          body-stream
                          (if raw-stream?
                            content
                            (netty/buf->array content))))
 
-           (when-not raw-stream?
+           (when (or (not raw-stream?) content-empty?)
              (.release ^ReferenceCounted msg))
 
            (when (.isEndStream ^Http2DataFrame msg)

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -791,12 +791,10 @@
         (is (= ""
                (bs/to-string (:body @(http-get path)))))))
     (testing "Client is slow to write, but has time"
-      (with-http-servers echo-handler {:idle-timeout 200
-                                          :raw-stream?  true}
+      (with-http-servers echo-handler {:idle-timeout 200}
         (is (= "012345" (bs/to-string (:body @(http-put path {:body (slow-stream)})))))))
     (testing "Client is too slow to write"
-      (with-http-servers echo-handler {:idle-timeout 30
-                                          :raw-stream?  true}
+      (with-http-servers echo-handler {:idle-timeout 30}
         (is (thrown-with-msg? Exception #"connection was close"
                               (bs/to-string (:body @(http-put path {:body (slow-stream)})))))))))
 ;;;


### PR DESCRIPTION
The client idle-timeout tests were using raw handlers but the local `echo-handler` didn't release the body buffers. Fix by not using raw handlers in the first place (which was unnecessary here).

Took the liberty to also enable leak detection for the whole test suite in CI with this PR.

Closes #707.