### PR TITLE
Allow custom `SslContext` without ALPN again for HTTP/1.1-only case

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -208,11 +208,17 @@
            control-period       60000
            middleware           middleware/wrap-request
            max-queue-size       65536}}]
-  (when (and (false? (:keep-alive? connection-options))
-             (pos? (:idle-timeout connection-options 0)))
-    (throw
-      (IllegalArgumentException.
+  (let [{:keys [keep-alive?
+                idle-timeout
+                http-versions
+                force-h2c?]
+         :or {idle-timeout 0}} connection-options]
+    (when (and (false? keep-alive?) (pos? idle-timeout))
+      (throw
+       (IllegalArgumentException.
         ":idle-timeout option is not allowed when :keep-alive? is explicitly disabled")))
+    (when (and force-h2c? (not-any? #{:http2} http-versions))
+      (throw (IllegalArgumentException. "force-h2c? may only be true when HTTP/2 is enabled."))))
 
   (let [log-activity (:log-activity connection-options)
         dns-options' (if-not (and (some? dns-options)

--- a/src/aleph/http/common.clj
+++ b/src/aleph/http/common.clj
@@ -194,7 +194,7 @@
         ssl-context)
       (if (= [:http1] desired-http-versions)
         ssl-context
-        (throw (ex-info "No ALPN supplied, but requested non-HTTP/1 versions that require ALPN."
+        (throw (ex-info "Supplied SslContext with no ALPN config, but requested secure non-HTTP/1 versions that require ALPN."
                         {:desired-http-versions desired-http-versions}))))))
 
 (defn validate-http1-pipeline-transform

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -1339,7 +1339,7 @@
     (catch Exception e
       e)))
 
-(deftest test-http-versions-config
+(deftest test-http-versions-server-config
   (testing "ssl-context as options map"
 
     (testing "with different HTTP versions in ALPN config"
@@ -1424,12 +1424,18 @@
                                           (netty/application-protocol-config [:http2 :http1])))})]
         (is (= :started result))))
 
-    (testing "with no ALPN config"
+    (testing "with no ALPN config but desiring HTTP/2"
       (let [result (try-start-server
                     {:http-versions [:http2 :http1]
                      :ssl-context test-ssl/server-ssl-context})]
         (is (instance? ExceptionInfo result))
-        (is (= "Some desired HTTP versions are not part of ALPN config." (ex-message result))))))
+        (is (= "No ALPN supplied, but requested non-HTTP/1 versions that require ALPN." (ex-message result)))))
+
+    (testing "with no ALPN config but desiring only HTTP/1"
+      (let [result (try-start-server
+                    {:http-versions [:http1]
+                     :ssl-context test-ssl/server-ssl-context})]
+        (is (= :started result)))))
 
   (testing "HTTP/2 without ssl-context"
     (let [result (try-start-server

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -1429,7 +1429,7 @@
                     {:http-versions [:http2 :http1]
                      :ssl-context test-ssl/server-ssl-context})]
         (is (instance? ExceptionInfo result))
-        (is (= "No ALPN supplied, but requested non-HTTP/1 versions that require ALPN." (ex-message result)))))
+        (is (= "Supplied SslContext with no ALPN config, but requested secure non-HTTP/1 versions that require ALPN." (ex-message result)))))
 
     (testing "with no ALPN config but desiring only HTTP/1"
       (let [result (try-start-server
@@ -1583,7 +1583,7 @@
                        {:http-versions [:http2 :http1]
                         :ssl-context test-ssl/client-ssl-context}})]
           (is (instance? ExceptionInfo result))
-          (is (= "No ALPN supplied, but requested non-HTTP/1 versions that require ALPN." (ex-message result)))))
+          (is (= "Supplied SslContext with no ALPN config, but requested secure non-HTTP/1 versions that require ALPN." (ex-message result)))))
 
       (testing "with no ALPN config but desiring only HTTP/1"
         (let [result (try-request-with-pool

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -1609,7 +1609,15 @@
                       {:connection-options
                        {:force-h2c? true
                         :http-versions [:http2]}})]
-          (is (= :success result)))))))
+          (is (= :success result))))
+
+      (testing "h2c without HTTP/2"
+        (let [result (try-request-with-pool
+                      {:connection-options
+                       {:force-h2c? true
+                        :http-versions [:http1]}})]
+          (is (instance? IllegalArgumentException result))
+          (is (= "force-h2c? may only be true when HTTP/2 is enabled." (ex-message result))))))))
 
 
 (deftest test-in-flight-request-cancellation


### PR DESCRIPTION
With the introduction of HTTP/2 support, Aleph started to require a matching ALPN config to be present in custom `SslContext` objects. This needlessly broke existing HTTP/1.1-only uses. With this change, we now allow custom `SslContext` objects without ALPN config again if only HTTP/1.1 is desired (via the `http-versions` option). Since this still happens to be the default, existing uses should just work again.

Fixes #727

----

@KingMob your suggested patch *almost* worked as-is but was thwarted by the fact that `applicationProtocolNegotiator` is always present (see code comment).

Review welcome but don't merge, yet, as I also would like to add a `test-http-versions-client-config` test which mirrors `test-http-versions-server-config` for the client (as that's what #727 was originally about).