### PR TITLE
Demote HTTPS connection info log to debug

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -643,8 +643,8 @@
                             :pipeline pipeline)]
       (cond ssl?
             (let [ssl-handler (netty/ssl-handler (.channel pipeline) ssl-context)]
-              (log/info "Setting up secure HTTP server pipeline.")
-              (log/info "ALPN HTTP versions:" (mapv str (.nextProtocols ssl-context)))
+              (log/debug "Setting up secure HTTP server pipeline.")
+              (log/debug "ALPN HTTP versions:" (mapv str (.nextProtocols ssl-context)))
 
               (-> pipeline
                   (.addLast "ssl-handler" ssl-handler)


### PR DESCRIPTION
Logging every established HTTPS connection along with its ALPN protocols is unnecessarily verbose without adding much value (there's no way to identify the connection, for example), so demote these to debug level. Users can still get higher-value logs, e.g. via ring middleware.

Follow-up to #719.