### PR TITLE
Update netty to 4.1.115 in order to avoid getting flagged for CVE-2024-47535

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,24 +10,24 @@
   org.clj-commons/dirigiste {:mvn/version "1.0.4"},
   org.clj-commons/primitive-math {:mvn/version "1.0.1"},
   potemkin/potemkin {:mvn/version "0.4.7"},
-  io.netty/netty-transport {:mvn/version "4.1.111.Final"},
+  io.netty/netty-transport {:mvn/version "4.1.115.Final"},
   io.netty/netty-transport-native-epoll$linux-x86_64
-  {:mvn/version "4.1.111.Final"},
+  {:mvn/version "4.1.115.Final"},
   io.netty/netty-transport-native-epoll$linux-aarch_64
-  {:mvn/version "4.1.111.Final"},
+  {:mvn/version "4.1.115.Final"},
   io.netty/netty-transport-native-kqueue$osx-x86_64
-  {:mvn/version "4.1.111.Final"},
+  {:mvn/version "4.1.115.Final"},
   io.netty.incubator/netty-incubator-transport-native-io_uring$linux-x86_64
   {:mvn/version "0.0.25.Final"},
   io.netty.incubator/netty-incubator-transport-native-io_uring$linux-aarch_64
   {:mvn/version "0.0.25.Final"},
-  io.netty/netty-codec {:mvn/version "4.1.111.Final"},
-  io.netty/netty-codec-http {:mvn/version "4.1.111.Final"},
-  io.netty/netty-codec-http2 {:mvn/version "4.1.111.Final"},
-  io.netty/netty-handler {:mvn/version "4.1.111.Final"},
-  io.netty/netty-handler-proxy {:mvn/version "4.1.111.Final"},
-  io.netty/netty-resolver {:mvn/version "4.1.111.Final"},
-  io.netty/netty-resolver-dns {:mvn/version "4.1.111.Final"},
+  io.netty/netty-codec {:mvn/version "4.1.115.Final"},
+  io.netty/netty-codec-http {:mvn/version "4.1.115.Final"},
+  io.netty/netty-codec-http2 {:mvn/version "4.1.115.Final"},
+  io.netty/netty-handler {:mvn/version "4.1.115.Final"},
+  io.netty/netty-handler-proxy {:mvn/version "4.1.115.Final"},
+  io.netty/netty-resolver {:mvn/version "4.1.115.Final"},
+  io.netty/netty-resolver-dns {:mvn/version "4.1.115.Final"},
   metosin/malli
   {:mvn/version "0.16.1", :exclusions [org.clojure/clojure]}},
  :aliases

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; you'll need to run the script at `deps/lein-to-deps` after changing any dependencies
-(def netty-version "4.1.111.Final")
+(def netty-version "4.1.115.Final")
 (def brotli-version "1.16.0")
 
 


### PR DESCRIPTION
Even though we don't deploy to Windows environments so [this vuln](https://github.com/netty/netty/security/advisories/GHSA-xq3w-v528-46rv) doesn't affect us, we like to avoid getting flagged it instead of going through an exception process.