### PR TITLE
Update Netty to 4.1.118.Final

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,24 +10,24 @@
   org.clj-commons/dirigiste {:mvn/version "1.0.4"},
   org.clj-commons/primitive-math {:mvn/version "1.0.1"},
   potemkin/potemkin {:mvn/version "0.4.7"},
-  io.netty/netty-transport {:mvn/version "4.1.115.Final"},
+  io.netty/netty-transport {:mvn/version "4.1.118.Final"},
   io.netty/netty-transport-native-epoll$linux-x86_64
-  {:mvn/version "4.1.115.Final"},
+  {:mvn/version "4.1.118.Final"},
   io.netty/netty-transport-native-epoll$linux-aarch_64
-  {:mvn/version "4.1.115.Final"},
+  {:mvn/version "4.1.118.Final"},
   io.netty/netty-transport-native-kqueue$osx-x86_64
-  {:mvn/version "4.1.115.Final"},
+  {:mvn/version "4.1.118.Final"},
   io.netty.incubator/netty-incubator-transport-native-io_uring$linux-x86_64
   {:mvn/version "0.0.25.Final"},
   io.netty.incubator/netty-incubator-transport-native-io_uring$linux-aarch_64
   {:mvn/version "0.0.25.Final"},
-  io.netty/netty-codec {:mvn/version "4.1.115.Final"},
-  io.netty/netty-codec-http {:mvn/version "4.1.115.Final"},
-  io.netty/netty-codec-http2 {:mvn/version "4.1.115.Final"},
-  io.netty/netty-handler {:mvn/version "4.1.115.Final"},
-  io.netty/netty-handler-proxy {:mvn/version "4.1.115.Final"},
-  io.netty/netty-resolver {:mvn/version "4.1.115.Final"},
-  io.netty/netty-resolver-dns {:mvn/version "4.1.115.Final"},
+  io.netty/netty-codec {:mvn/version "4.1.118.Final"},
+  io.netty/netty-codec-http {:mvn/version "4.1.118.Final"},
+  io.netty/netty-codec-http2 {:mvn/version "4.1.118.Final"},
+  io.netty/netty-handler {:mvn/version "4.1.118.Final"},
+  io.netty/netty-handler-proxy {:mvn/version "4.1.118.Final"},
+  io.netty/netty-resolver {:mvn/version "4.1.118.Final"},
+  io.netty/netty-resolver-dns {:mvn/version "4.1.118.Final"},
   metosin/malli
   {:mvn/version "0.16.1", :exclusions [org.clojure/clojure]}},
  :aliases

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; you'll need to run the script at `deps/lein-to-deps` after changing any dependencies
-(def netty-version "4.1.115.Final")
+(def netty-version "4.1.118.Final")
 (def brotli-version "1.16.0")
 
 

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -374,8 +374,8 @@
 
       (testing ":compression-level"
         (doseq [{:keys [phrase opts encs]}
-                [{:phrase "Gzip and deflate only for :compression-level"
-                  :opts   {:compression?        true
+                [{:phrase "All for :compression-level"
+                  :opts   {:compression-level   3
                            :idle-timeout        600000}
                   :encs   [{:accept-encoding  "gzip"
                             :content-encoding "gzip"
@@ -384,12 +384,15 @@
                             :content-encoding "deflate"
                             :stream-ctor      #(InflaterInputStream. %)}
                            {:accept-encoding  "br"
-                            :content-encoding nil
-                            :stream-ctor      identity}]}]]
+                            :content-encoding "br"
+                            :stream-ctor      #(BrotliInputStream. %)}
+                           {:accept-encoding  "zstd"
+                            :content-encoding "zstd"
+                            :stream-ctor      #(ZstdInputStream. %)}]}]]
           (testing phrase
             (doseq [{:keys [accept-encoding content-encoding stream-ctor]} encs]
               (testing (str " - " accept-encoding "-> " content-encoding)
-                (with-http1-server basic-handler {:compression-level 3}
+                (with-http1-server basic-handler opts
                   (doseq [[path result] expected-results]
                     (testing (str "/" path)
                       (let [resp @(http-get (str "/" path)


### PR DESCRIPTION
Fixes [CVE-2025-24970](https://github.com/netty/netty/security/advisories/GHSA-4g8c-wm8x-jfhw).