### PR TITLE
Adopting an existing, pre-bound server-socket channel

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -51,6 +51,7 @@
    | ---                               | --- |
    | `port`                            | The port the server will bind to. If `0`, the server will bind to a random port. |
    | `socket-address`                  | A `java.net.SocketAddress` specifying both the port and interface to bind to. |
+   | `existing-channel`                | A pre-bound `java.nio.channels.ServerSocketChannel` for the server to use rather than opening and binding its own server-socket. It won't be closed by the server. Possibly obtained from `System/inheritedChannel`. |
    | `bootstrap-transform`             | A function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it. |
    | `http-versions`                   | An optional vector of allowable HTTP versions to negotiate via ALPN, in preference order. Defaults to `[:http1]`. |
    | `ssl-context`                     | An `io.netty.handler.ssl.SslContext` object or a map of SSL context options (see `aleph.netty/ssl-server-context` for more details) if an SSL connection is desired. When passing an `io.netty.handler.ssl.SslContext` object, it must have an ALPN config matching the `http-versions` option (see `aleph.netty/ssl-server-context` and `aleph.netty/application-protocol-config`). If only HTTP/1.1 is desired, ALPN config is optional.

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -728,6 +728,7 @@
   [handler
    {:keys [port
            socket-address
+           existing-channel
            executor
            http-versions
            ssl-context
@@ -773,9 +774,10 @@
     (netty/start-server
       {:pipeline-builder    pipeline-builder
        :bootstrap-transform bootstrap-transform
-       :socket-address      (if socket-address
-                              socket-address
-                              (InetSocketAddress. port))
+       :socket-address      (cond
+                              socket-address socket-address
+                              (nil? existing-channel) (InetSocketAddress. port))
+       :existing-channel    existing-channel
        :on-close            (when (and shutdown-executor?
                                        (or (instance? ExecutorService executor)
                                            (instance? ExecutorService continue-executor)))

--- a/test/aleph/testutils.clj
+++ b/test/aleph/testutils.clj
@@ -1,8 +1,15 @@
 (ns aleph.testutils
-  (:import (io.netty.util AsciiString)))
+  (:import (io.netty.util AsciiString)
+           (java.net InetSocketAddress)
+           (java.nio.channels ServerSocketChannel)))
 
 (defn str=
   "AsciiString-aware equals"
   [^CharSequence x ^CharSequence y]
   (AsciiString/contentEquals x y))
 
+(defn bound-channel
+  "Returns a new server-socket channel bound to a `port`."
+  ^ServerSocketChannel [port]
+  (doto (ServerSocketChannel/open)
+    (.bind (InetSocketAddress. port))))


### PR DESCRIPTION
The use-case is to pass a server-socket channel, e.g. obtained by calling JVM's `System/inheritedChannel`. In this case, Aleph/Netty is not responsible for opening the channel nor closing it. It should simply listen on it. In other words, maintaining the connection sockets is still Aleph/Netty's responsibility, but not maintaining the listening socket if it has been passed to it.

* In the server startup part, this has been implemented as per Netty's Norman Maurer's advice [found here](https://stackoverflow.com/a/50196956).

* In the server shutdown part, Aleph is not shutting down nor closing the passed socket, because in practice it's owned by a process that passed it to Aleph process, and it's that parent process' responsibility to reuse or close it after Aleph process exits.

In terms of validation and fallback, for comparison, [this used to be Jetty's approach to adopting `inheritedChannel` at version 8](https://github.com/jetty/jetty.project/blob/jetty-8.0.0.v20110901/jetty-server/src/main/java/org/eclipse/jetty/server/nio/InheritedChannelConnector.java).

* Jetty automatically falls back to opening its own socket (with a warning) if the `inheritedChannel` is not supported or not present. In Aleph implementation, it refuses to start the server if the channel type is not supported, or the socket is not bound, but it silently falls back to an own socket if the passed channel is `nil`. As a result, it's Aleph user's responsibility to trigger an error if it expects an 'inherited channel' which is missing. Still, the user can expect that Aleph will fail early if a channel was actually passed, but it cannot be used.

* Unlike Jetty, Aleph doesn't itself call `configureBlocking false` on the channel because [this is done by Netty during server startup](https://github.com/netty/netty/blob/46d6e164a2a46e2c6d802f84e0c24abd475bcd89/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java#L84).