### PR TITLE
Extend listen-socket to epoll and kqueue transports

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -51,7 +51,7 @@
    | ---                               | --- |
    | `port`                            | The port the server will bind to. If `0`, the server will bind to a random port. |
    | `socket-address`                  | A `java.net.SocketAddress` specifying both the port and interface to bind to. |
-   | `existing-channel`                | A pre-bound `java.nio.channels.ServerSocketChannel` for the server to use rather than opening and binding its own server-socket. It won't be closed by the server. Possibly obtained from `System/inheritedChannel`. |
+   | `listen-socket`                   | A pre-bound server-socket as a `java.nio.channels.ServerSocketChannel` (NIO transport) or a `long` file descriptor (epoll and kqueue transports) for the server to use rather than opening and binding its own server-socket. It won't be closed by the server. Possibly obtained from `System/inheritedChannel`. |
    | `bootstrap-transform`             | A function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it. |
    | `http-versions`                   | An optional vector of allowable HTTP versions to negotiate via ALPN, in preference order. Defaults to `[:http1]`. |
    | `ssl-context`                     | An `io.netty.handler.ssl.SslContext` object or a map of SSL context options (see `aleph.netty/ssl-server-context` for more details) if an SSL connection is desired. When passing an `io.netty.handler.ssl.SslContext` object, it must have an ALPN config matching the `http-versions` option (see `aleph.netty/ssl-server-context` and `aleph.netty/application-protocol-config`). If only HTTP/1.1 is desired, ALPN config is optional.

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -737,7 +737,7 @@
   [handler
    {:keys [port
            socket-address
-           existing-channel
+           listen-socket
            executor
            http-versions
            ssl-context
@@ -789,8 +789,8 @@
        :bootstrap-transform bootstrap-transform
        :socket-address      (cond
                               socket-address socket-address
-                              (nil? existing-channel) (InetSocketAddress. port))
-       :existing-channel    existing-channel
+                              (nil? listen-socket) (InetSocketAddress. port))
+       :listen-socket       listen-socket
        :on-close            (when (and shutdown-executor?
                                        (or (instance? ExecutorService executor)
                                            (instance? ExecutorService continue-executor)))

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -74,7 +74,7 @@
    | ---                   | ---
    | `port`                | the port the server will bind to.  If `0`, the server will bind to a random port.
    | `socket-address`      | a `java.net.SocketAddress` specifying both the port and interface to bind to.
-   | `existing-channel`    | a pre-bound `java.nio.channels.ServerSocketChannel` for the server to use rather than opening and binding its own server-socket. It won't be closed by the server. Possibly obtained from `System/inheritedChannel`. |
+   | `listen-socket`       | a pre-bound server-socket as a `java.nio.channels.ServerSocketChannel` (NIO transport) or a `long` file descriptor (epoll and kqueue transports) for the server to use rather than opening and binding its own server-socket. It won't be closed by the server. Possibly obtained from `System/inheritedChannel`.
    | `ssl-context`         | an `io.netty.handler.ssl.SslContext` object or a map of SSL context options (see `aleph.netty/ssl-server-context` for more details). If given, the server will only accept SSL connections and call the handler once the SSL session has been successfully established. If a self-signed certificate is all that's required, `(aleph.netty/self-signed-ssl-context)` will suffice.
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it.
    | `pipeline-transform`  | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
@@ -82,7 +82,7 @@
    | `shutdown-timeout`    | interval in seconds within which in-flight requests must be processed, defaults to 15 seconds. A value of 0 bypasses waiting entirely.
    | `transport`           | the transport to use, one of `:nio`, `:epoll`, `:kqueue` or `:io-uring` (defaults to `:nio`)."
   [handler
-   {:keys [port socket-address existing-channel ssl-context bootstrap-transform pipeline-transform epoll?
+   {:keys [port socket-address listen-socket ssl-context bootstrap-transform pipeline-transform epoll?
            shutdown-timeout transport]
     :or {bootstrap-transform identity
          pipeline-transform identity
@@ -104,8 +104,8 @@
       :bootstrap-transform bootstrap-transform
       :socket-address (cond
                         socket-address socket-address
-                        (nil? existing-channel) (InetSocketAddress. port))
-      :existing-channel existing-channel
+                        (nil? listen-socket) (InetSocketAddress. port))
+      :listen-socket listen-socket
       :transport (netty/determine-transport transport epoll?)
       :shutdown-timeout shutdown-timeout})))
 

--- a/test/aleph/tcp_test.clj
+++ b/test/aleph/tcp_test.clj
@@ -56,11 +56,11 @@
       (catch Exception _
         (is (not (netty/io-uring-available?)))))))
 
-(deftest test-existing-channel
-  (testing "the :port option is not required when :existing-channel is passed"
+(deftest test-listen-socket
+  (testing "the :port option is not required when :listen-socket is passed"
     (let [port 8083]
       (with-open [channel (bound-channel port)]
-        (with-server (tcp/start-server echo-handler {:existing-channel channel :shutdown-timeout 0})
+        (with-server (tcp/start-server echo-handler {:listen-socket channel :shutdown-timeout 0})
           (let [c @(tcp/client {:host "localhost" :port port})]
             (s/put! c "foo")
             (is (= "foo" (bs/to-string @(s/take! c))))))))))


### PR DESCRIPTION
The `existing-channel` option added in #748 works only with NIO transport (Aleph default). When trying to use it with epoll, we would get a Netty error: `incompatible event loop type:
io.netty.channel.epoll.EpollEventLoop`.

This is not surprising, since the server-channel class to use depends on the transport, as per
[`transport-server-channel-class`](https://github.com/clj-commons/aleph/blob/5a0c6976aa42f30ca3786cef64f9ba70cf037ae1/src/aleph/netty.clj#L1327) and the `existing-channel` handling was always creating a NIO server-channel regardless of transport.

It’s not difficult to support most of the other transports. We just have to use the server-channel class as per the aforementioned fn. Their constructors in case of epoll and kqueue take an FD number rather than Java channel. There is no suitable constructor for io-uring, so it is not supported. The validation has been updated accordingly.

The full integration test is still limited to NIO, because obtaining an FD of a server-socket opened in Java requires deep reflection (the `--add-opens` flag), which would add some complexity (perhaps a dedicated lein profile) just to test this. The validation test checks that the FD route is attempted for the other transports, but it stops at `Bad file descriptor` error.

The option is being renamed from `existing-channel` to `listen-socket`, because this seems more fitting when we are accepting not just channels but also FDs. The `existing-channel` was merged very recently and hasn’t yet been released in a maven version.