### PR TITLE
Upgrade `netty-version` to `4.1.124.Final`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,24 +10,24 @@
   org.clj-commons/dirigiste {:mvn/version "1.0.4"},
   org.clj-commons/primitive-math {:mvn/version "1.0.1"},
   potemkin/potemkin {:mvn/version "0.4.8"},
-  io.netty/netty-transport {:mvn/version "4.1.122.Final"},
+  io.netty/netty-transport {:mvn/version "4.1.124.Final"},
   io.netty/netty-transport-native-epoll$linux-x86_64
-  {:mvn/version "4.1.122.Final"},
+  {:mvn/version "4.1.124.Final"},
   io.netty/netty-transport-native-epoll$linux-aarch_64
-  {:mvn/version "4.1.122.Final"},
+  {:mvn/version "4.1.124.Final"},
   io.netty/netty-transport-native-kqueue$osx-x86_64
-  {:mvn/version "4.1.122.Final"},
+  {:mvn/version "4.1.124.Final"},
   io.netty.incubator/netty-incubator-transport-native-io_uring$linux-x86_64
   {:mvn/version "0.0.26.Final"},
   io.netty.incubator/netty-incubator-transport-native-io_uring$linux-aarch_64
   {:mvn/version "0.0.26.Final"},
-  io.netty/netty-codec {:mvn/version "4.1.122.Final"},
-  io.netty/netty-codec-http {:mvn/version "4.1.122.Final"},
-  io.netty/netty-codec-http2 {:mvn/version "4.1.122.Final"},
-  io.netty/netty-handler {:mvn/version "4.1.122.Final"},
-  io.netty/netty-handler-proxy {:mvn/version "4.1.122.Final"},
-  io.netty/netty-resolver {:mvn/version "4.1.122.Final"},
-  io.netty/netty-resolver-dns {:mvn/version "4.1.122.Final"},
+  io.netty/netty-codec {:mvn/version "4.1.124.Final"},
+  io.netty/netty-codec-http {:mvn/version "4.1.124.Final"},
+  io.netty/netty-codec-http2 {:mvn/version "4.1.124.Final"},
+  io.netty/netty-handler {:mvn/version "4.1.124.Final"},
+  io.netty/netty-handler-proxy {:mvn/version "4.1.124.Final"},
+  io.netty/netty-resolver {:mvn/version "4.1.124.Final"},
+  io.netty/netty-resolver-dns {:mvn/version "4.1.124.Final"},
   metosin/malli
   {:mvn/version "0.19.1", :exclusions [org.clojure/clojure]}},
  :aliases

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
 ;; you'll need to run the script at `deps/lein-to-deps` after changing any dependencies
-(def netty-version "4.1.122.Final")
+(def netty-version "4.1.124.Final")
 (def brotli-version "1.18.0")
 
 
-(defproject aleph (or (System/getenv "PROJECT_VERSION") "0.9.0")
+(defproject aleph (or (System/getenv "PROJECT_VERSION") "0.9.1")
   :description "A framework for asynchronous communication"
   :url "https://github.com/clj-commons/aleph"
   :license {:name "MIT License"}


### PR DESCRIPTION
to address [CVE-2025-55163](https://www.mend.io/vulnerability-database/CVE-2025-55163)