### PR TITLE
fix(req-headers): Set headers instead of adding duplicates when key is a singleton 

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -157,6 +157,10 @@
   [^HttpHeaders h]
   (HeaderMap. h nil nil nil))
 
+(def singleton-header-names
+  #{"Content-Type" "Content-Length" "Content-Location" "Content-Range"
+    "Location" "ETag" "Last-Modified" "Expires" "Age" "Retry-After"
+    "Transfer-Encoding" "Content-Encoding" "Server" "Date"})
 (defn map->headers!
   "Despite the name, this doesn't convert; it adds headers from the Ring :headers
    map to the Netty HttpHeaders param."
@@ -170,10 +174,14 @@
         (throw (IllegalArgumentException. (str "nil value for header key '" k "'")))
 
         (sequential? v)
-        (.add h ^CharSequence k ^Iterable v)
+        (if (contains? singleton-header-names k)
+          (.set h ^CharSequence k ^Iterable v)
+          (.add h ^CharSequence k ^Iterable v))
 
         :else
-        (.add h ^CharSequence k ^Object v)))))
+        (if (contains? singleton-header-names k)
+          (.set h ^CharSequence k ^Object v)
+          (.add h ^CharSequence k ^Object v))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; HTTP/1.1 request/response handling

--- a/test/aleph/http/core_test.clj
+++ b/test/aleph/http/core_test.clj
@@ -12,8 +12,12 @@
                                    :headers {"Accept"                "text/html"
                                              "Authorization"         "Basic narfdorfle"
                                              :Content                "text/test"}})
+                                            "Content-type"           "application/json"
+                                            "content-type"           "application/json"
         m (core/headers->map (.headers req))
         changed-map (-> m
                         (assoc "x-tra" "foobar")
                         (dissoc "authorization" "content"))]
+    (is (= "application/json" (-> req .headers (.get "Content-Type")))
+        "normalize will not allow duplicates for singleton keys, we get a single value out")
     (is (= #{"accept" "x-tra"} (-> changed-map keys set)))))

--- a/test/aleph/http/core_test.clj
+++ b/test/aleph/http/core_test.clj
@@ -7,17 +7,18 @@
 
 (deftest test-HeaderMap-keys
   (let [^DefaultHttpRequest req (core/ring-request->netty-request
-                                  {:uri "http://example.com"
-                                   :request-method "get"
-                                   :headers {"Accept"                "text/html"
-                                             "Authorization"         "Basic narfdorfle"
-                                             :Content                "text/test"}})
-                                            "Content-type"           "application/json"
-                                            "content-type"           "application/json"
+                                 {:uri "http://example.com"
+                                  :request-method "get"
+                                  :headers {"Accept"        "text/html"
+                                            "Authorization" "Basic narfdorfle"
+                                            :Content        "text/test"
+                                            "Content-type"  "application/json"
+                                            "content-type"  "application/json"}})
+
         m (core/headers->map (.headers req))
         changed-map (-> m
                         (assoc "x-tra" "foobar")
                         (dissoc "authorization" "content"))]
     (is (= "application/json" (-> req .headers (.get "Content-Type")))
         "normalize will not allow duplicates for singleton keys, we get a single value out")
-    (is (= #{"accept" "x-tra"} (-> changed-map keys set)))))
+    (is (= #{"content-type" "accept" "x-tra"} (-> changed-map keys set)))))


### PR DESCRIPTION
The HTTP specifications define (and in some cases hints at) several headers as singletons (should appear only once) in responses, and aleph will create duplicates if we have multiple keys with the different casing. 
While I understand the user should be careful, the server could also prevent that to happen.