### PR TITLE
Update Netty to 4.1.132

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,24 +10,24 @@
   org.clj-commons/dirigiste {:mvn/version "1.0.4"},
   org.clj-commons/primitive-math {:mvn/version "1.0.1"},
   potemkin/potemkin {:mvn/version "0.4.8"},
-  io.netty/netty-transport {:mvn/version "4.1.130.Final"},
+  io.netty/netty-transport {:mvn/version "4.1.132.Final"},
   io.netty/netty-transport-native-epoll$linux-x86_64
-  {:mvn/version "4.1.130.Final"},
+  {:mvn/version "4.1.132.Final"},
   io.netty/netty-transport-native-epoll$linux-aarch_64
-  {:mvn/version "4.1.130.Final"},
+  {:mvn/version "4.1.132.Final"},
   io.netty/netty-transport-native-kqueue$osx-x86_64
-  {:mvn/version "4.1.130.Final"},
+  {:mvn/version "4.1.132.Final"},
   io.netty.incubator/netty-incubator-transport-native-io_uring$linux-x86_64
   {:mvn/version "0.0.26.Final"},
   io.netty.incubator/netty-incubator-transport-native-io_uring$linux-aarch_64
   {:mvn/version "0.0.26.Final"},
-  io.netty/netty-codec {:mvn/version "4.1.130.Final"},
-  io.netty/netty-codec-http {:mvn/version "4.1.130.Final"},
-  io.netty/netty-codec-http2 {:mvn/version "4.1.130.Final"},
-  io.netty/netty-handler {:mvn/version "4.1.130.Final"},
-  io.netty/netty-handler-proxy {:mvn/version "4.1.130.Final"},
-  io.netty/netty-resolver {:mvn/version "4.1.130.Final"},
-  io.netty/netty-resolver-dns {:mvn/version "4.1.130.Final"},
+  io.netty/netty-codec {:mvn/version "4.1.132.Final"},
+  io.netty/netty-codec-http {:mvn/version "4.1.132.Final"},
+  io.netty/netty-codec-http2 {:mvn/version "4.1.132.Final"},
+  io.netty/netty-handler {:mvn/version "4.1.132.Final"},
+  io.netty/netty-handler-proxy {:mvn/version "4.1.132.Final"},
+  io.netty/netty-resolver {:mvn/version "4.1.132.Final"},
+  io.netty/netty-resolver-dns {:mvn/version "4.1.132.Final"},
   metosin/malli
   {:mvn/version "0.20.0", :exclusions [org.clojure/clojure]}},
  :aliases

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; you'll need to run the script at `deps/lein-to-deps` after changing any dependencies
-(def netty-version "4.1.130.Final")
+(def netty-version "4.1.132.Final")
 (def brotli-version "1.20.0")
 
 


### PR DESCRIPTION
Fixes CVE-2026-33870 and CVE-2026-33871.